### PR TITLE
Types for transformed explorer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,8 +43,26 @@ export interface OptionsSync extends OptionsBase {
   transform?: TransformSync;
 }
 
+type ExplorerLike = Readonly<Explorer>;
+type TypedTransform<T> =
+  | ((CosmiconfigResult: CosmiconfigResult) => Promise<T>)
+  | TypedTransformSync<T>;
+interface TypedOptions<T> extends Omit<Options, 'transform'> {
+  transform: TypedTransform<T>;
+}
+interface TypedExplorer<T> extends Omit<ExplorerLike, 'search' | 'load'> {
+  readonly search: (searchFrom?: string) => Promise<T>;
+  readonly load: (filepath: string) => Promise<T>;
+}
+
+function cosmiconfig<T>(
+  moduleName: string,
+  options: TypedOptions<T>,
+): TypedExplorer<T>;
+function cosmiconfig(moduleName: string, options?: Options): ExplorerLike;
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function cosmiconfig(moduleName: string, options: Options = {}) {
+function cosmiconfig(moduleName: string, options: Options = {}): ExplorerLike {
   const normalizedOptions: ExplorerOptions = normalizeOptions(
     moduleName,
     options,
@@ -60,6 +78,31 @@ function cosmiconfig(moduleName: string, options: Options = {}) {
     clearCaches: explorer.clearCaches.bind(explorer),
   } as const;
 }
+
+interface ExplorerSyncLike
+  extends Omit<ExplorerSync, 'searchSync' | 'loadSync'> {
+  readonly search: ExplorerSync['searchSync'];
+  readonly load: ExplorerSync['loadSync'];
+}
+
+type TypedTransformSync<T> = (CosmiconfigResult: CosmiconfigResult) => T;
+interface TypedOptionsSync<T> extends Omit<Options, 'transform'> {
+  transform: TypedTransformSync<T>;
+}
+interface TypedExplorerSync<T>
+  extends Omit<ExplorerSyncLike, 'search' | 'load'> {
+  search(searchFrom?: string): T;
+  load(filepath: string): T;
+}
+
+function cosmiconfigSync<T>(
+  moduleName: string,
+  options?: TypedOptionsSync<T>,
+): TypedExplorerSync<T>;
+function cosmiconfigSync(
+  moduleName: string,
+  options?: OptionsSync,
+): ExplorerSyncLike;
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function cosmiconfigSync(moduleName: string, options: OptionsSync = {}) {

--- a/test/caches.test.ts
+++ b/test/caches.test.ts
@@ -52,6 +52,7 @@ describe('cache is not used initially', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     const cachedSearchSync = cosmiconfigSync('foo').search;
     const result = cachedSearchSync(searchPath);
     checkResult(readFileSpy, result);
@@ -83,6 +84,7 @@ describe('cache is used for already-visited directories', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     const cachedSearchSync = cosmiconfigSync('foo').search;
     // First pass, prime the cache ...
     cachedSearchSync(searchPath);
@@ -119,6 +121,7 @@ describe('cache is used for already-loaded file', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     const cachedLoadSync = cosmiconfigSync('foo').load;
     // First pass, prime the cache ...
     cachedLoadSync(loadPath);
@@ -165,6 +168,7 @@ describe('cache is used when some directories in search are already visted', () 
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     const cachedSearchSync = cosmiconfigSync('foo').search;
     // First pass, prime the cache ...
     cachedSearchSync(firstSearchPath);

--- a/test/failed-directories.test.ts
+++ b/test/failed-directories.test.ts
@@ -526,9 +526,8 @@ describe('throws error if an extensionless file in searchPlaces does not have a 
   const explorerOptions: OptionsSync = {
     stopDir: temp.absolutePath('.'),
     searchPlaces: ['package.json', '.foorc'],
-    // @ts-ignore
     loaders: {
-      noExt: undefined,
+      noExt: undefined as never,
     },
   };
 


### PR DESCRIPTION
I am using this package in one of my typescript projects, I noticed an `Explorer` (or `ExplorerSync`) `search` and `load` methods signature does not change even if you use the `transform` option, this PR fixes that. I kept the original signature as fallback so no code will be broken. This is not a functionality issue it's a types issue, the methods work as intended, just the types are wrong.

Note that this is a "quick and easy" fix, there are a lot of improvement that can be done "typeswise". I tried to keep all changes contained so it's easy to review.