### PR TITLE
Support ECMAScript modules (ESM)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,6 +112,7 @@ module.exports = {
     // Many tests make assertions indirectly in a way the plugin
     // does not understand.
     'jest/expect-expect': 'off',
+    'jest/no-identical-title': 'off',
   },
   settings: {
     node: {

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ git:
   depth: 5
 cache: yarn
 branches:
-  only:
-    - main
-    - v7
+  # only:
+  #   - main
+  #   - v7
 matrix:
   include:
     - node_js: '10'
-      after_success: 'bash <(curl -s https://codecov.io/bash)'
     - node_js: '12'
     - node_js: '14'
+      after_success: 'bash <(curl -s https://codecov.io/bash)'
 install:
   - yarn install --frozen-lockfile
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## HEAD
+
+- **Breaking change:** Add support for ECMAScript modules (ESM) to the [*asynchronous* API](./README.md#asynchronous-api). End users running Node versions that support ESM can provide `.mjs` files, or `.js` files whose nearest parent `package.json` file contains `"type": "module"`.
+  - `${moduleName}rc.mjs` and `${moduleName}.config.mjs` are included in the default `searchPlaces` of the asynchronous API.
+  - The [synchronous API](./README.md#synchronous-api) does not support ECMAScript modules, so does not look for `.mjs` files.
+  - To learn more, read ["Loading JS modules"](./README.md#loading-js-modules).
+
 ## 7.0.0
 
 - **Breaking change:** Add `${moduleName}rc.cjs` and `${moduleName}.config.cjs` to the default `searchPlaces`, to support users of `"type": "module"` in recent versions of Node.

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ By default, Cosmiconfig will start where you tell it to start and search up the 
 
 - a `package.json` property
 - a JSON or YAML, extensionless "rc file"
-- an "rc file" with the extensions `.json`, `.yaml`, `.yml`, `.js`, or `.cjs`
-- a `.config.js` or `.config.cjs` CommonJS module
+- an "rc file" with the extensions `.json`, `.yaml`, `.yml`, `.js`, `.mjs`, or `.cjs`
+- a `.config.js`, `.config.mjs`, or `.config.cjs` file
 
 For example, if your module's name is "myapp", cosmiconfig will search up the directory tree for configuration in the following places:
 
 - a `myapp` property in `package.json`
 - a `.myapprc` file in JSON or YAML format
-- a `.myapprc.json`, `.myapprc.yaml`, `.myapprc.yml`, `.myapprc.js`, or `.myapprc.cjs` file
-- a `myapp.config.js` or `myapp.config.cjs` CommonJS module exporting an object
+- a `.myapprc.json`, `.myapprc.yaml`, `.myapprc.yml`, `.myapprc.js`, `.myapprc.mjs`, or `.myapprc.cjs` file
+- a `myapp.config.js`, `myapp.config.mjs`, or `myapp.config.cjs` file
 
 Cosmiconfig continues to search up the directory tree, checking each of these places in each directory, until it finds some acceptable configuration (or hits the home directory).
 
@@ -51,6 +51,7 @@ Cosmiconfig continues to search up the directory tree, checking each of these pl
   - [cache](#cache)
   - [transform](#transform)
   - [ignoreEmptySearchPlaces](#ignoreemptysearchplaces)
+- [Loading JS modules](#loading-js-modules)
 - [Caching](#caching)
 - [Differences from rc](#differences-from-rc)
 - [Contributing & Development](#contributing--development)
@@ -142,11 +143,12 @@ Here's how your default [`search()`] will work:
 - Starting from `process.cwd()` (or some other directory defined by the `searchFrom` argument to [`search()`]), look for configuration objects in the following places:
   1. A `goldengrahams` property in a `package.json` file.
   2. A `.goldengrahamsrc` file with JSON or YAML syntax.
-  3. A `.goldengrahamsrc.json`, `.goldengrahamsrc.yaml`, `.goldengrahamsrc.yml`, `.goldengrahamsrc.js`, or `.goldengrahamsrc.cjs` file.
-  4. A `goldengrahams.config.js` or `goldengrahams.config.cjs` CommonJS module exporting the object.
+  3. A `.goldengrahamsrc.json`, `.goldengrahamsrc.yaml`, `.goldengrahamsrc.yml`, `.goldengrahamsrc.js`, or `.goldengrahamsrc.cjs` file. (To learn more about how JS files are loaded, see ["Loading JS modules"].)
+  4. A `goldengrahams.config.js`, `goldengrahams.config.mjs`, or `goldengrahams.config.cjs` file. (To learn more about how JS files are loaded, see ["Loading JS modules"].)
 - If none of those searches reveal a configuration object, move up one directory level and try again.
   So the search continues in `./`, `../`, `../../`, `../../../`, etc., checking the same places in each directory.
 - Continue searching until arriving at your home directory (or some other directory defined by the cosmiconfig option [`stopDir`]).
+- For JS files,
 - If at any point a parsable configuration is found, the [`search()`] Promise resolves with its [result] \(or, with [`explorerSync.search()`], the [result] is returned).
 - If no configuration object is found, the [`search()`] Promise resolves with `null` (or, with [`explorerSync.search()`], `null` is returned).
 - If a configuration object is found *but is malformed* (causing a parsing error), the [`search()`] Promise rejects with that error (so you should `.catch()` it). (Or, with [`explorerSync.search()`], the error is thrown.)
@@ -258,6 +260,8 @@ Each place is relative to the directory being searched, and the places are check
 
 **Default `searchPlaces`:**
 
+For the [asynchronous API](#asynchronous-api), these are the default `searchPlaces`:
+
 ```js
 [
   'package.json',
@@ -266,11 +270,15 @@ Each place is relative to the directory being searched, and the places are check
   `.${moduleName}rc.yaml`,
   `.${moduleName}rc.yml`,
   `.${moduleName}rc.js`,
+  `.${moduleName}rc.mjs`,
   `.${moduleName}rc.cjs`,
   `${moduleName}.config.js`,
+  `${moduleName}.config.mjs`,
   `${moduleName}.config.cjs`,
 ]
 ```
+
+For the [synchronous API](#synchronous-api), the only difference is that `.mjs` files are not included. See ["Loading JS modules"] for more information.
 
 Create your own array to search more, fewer, or altogether different places.
 
@@ -291,20 +299,10 @@ Examples, with a module named `porgy`:
   'porgy.config.js'
 ]
 
-// ESLint searches for configuration in these places:
-[
-  '.eslintrc.js',
-  '.eslintrc.yaml',
-  '.eslintrc.yml',
-  '.eslintrc.json',
-  '.eslintrc',
-  'package.json'
-]
-
-// Babel looks in fewer places:
+// Limit the options dramatically:
 [
   'package.json',
-  '.babelrc'
+  '.porgyrc'
 ]
 
 // Maybe you want to look for a wide variety of JS flavors:
@@ -315,7 +313,7 @@ Examples, with a module named `porgy`:
   'porgy.config.coffee'
 ]
 // ^^ You will need to designate custom loaders to tell
-// Cosmiconfig how to handle these special JS flavors.
+// Cosmiconfig how to handle `.ts` and `.coffee` files.
 
 // Look within a .config/ subdirectory of every searched directory:
 [
@@ -334,17 +332,28 @@ Default: See below.
 
 An object that maps extensions to the loader functions responsible for loading and parsing files with those extensions.
 
-Cosmiconfig exposes its default loaders on a named export `defaultLoaders`.
+Cosmiconfig exposes its default loaders on the named export `defaultLoaders` and `defaultLoadersSync`.
 
 **Default `loaders`:**
 
 ```js
-const { defaultLoaders } = require('cosmiconfig');
+const { defaultLoaders, defaultLoadersSync } = require('cosmiconfig');
 
 console.log(Object.entries(defaultLoaders))
 // [
+//   [ '.mjs', [Function: loadJs] ],
 //   [ '.cjs', [Function: loadJs] ],
 //   [ '.js', [Function: loadJs] ],
+//   [ '.json', [Function: loadJson] ],
+//   [ '.yaml', [Function: loadYaml] ],
+//   [ '.yml', [Function: loadYaml] ],
+//   [ 'noExt', [Function: loadYaml] ]
+// ]
+
+console.log(Object.entries(defaultLoadersSync))
+// [
+//   [ '.cjs', [Function: loadJsSync] ],
+//   [ '.js', [Function: loadJsSync] ],
 //   [ '.json', [Function: loadJson] ],
 //   [ '.yaml', [Function: loadYaml] ],
 //   [ '.yml', [Function: loadYaml] ],
@@ -417,14 +426,12 @@ Examples:
 
 // Allow many flavors of JS, using custom loaders:
 {
-  '.mjs': esmLoader,
   '.ts': typeScriptLoader,
   '.coffee': coffeeScriptLoader
 }
 
 // Allow many flavors of JS but rely on require hooks:
 {
-  '.mjs': defaultLoaders['.js'],
   '.ts': defaultLoaders['.js'],
   '.coffee': defaultLoaders['.js']
 }
@@ -509,6 +516,18 @@ If you'd like to load empty configuration files, instead, set this option to `fa
 Why might you want to load empty configuration files?
 If you want to throw an error, or if an empty configuration file means something to your program.
 
+## Loading JS modules
+
+Your end users can provide JS configuration files as ECMAScript modules (ESM) under the following conditions:
+
+- You (the cosmiconfig user) use cosmiconfig's [asynchronous API](#asynchronous-api).
+- Your end user runs a version of Node that supports ESM ([>=12.17.0](https://nodejs.org/en/blog/release/v12.17.0/), or earlier with the `--experimental-modules` flag).
+- Your end user provides an `.mjs` configuration file, or a `.js` file whose nearest parent `package.json` file contains `"type": "module"`. (See [Node's method for determining a file's module system](https://nodejs.org/api/packages.html#packages_determining_module_system).)
+
+With cosmiconfig's [asynchronous API](#asynchronous-api), the default [`searchPlaces`] include `.js`, `.mjs`, and `.cjs` files. Cosmiconfig loads all these file types with the [dynamic `import` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports).
+
+With the [synchronous API](#synchronous-api), JS configuration files are always treated as CommonJS, and `.mjs` files are ignored, because there is no synchronous API for the dynamic `import` function.
+
 ## Caching
 
 As of v2, cosmiconfig uses caching to reduce the need for repetitious reading of the filesystem or expensive transforms. Every new cosmiconfig instance (created with `cosmiconfig()`) has its own caches.
@@ -570,3 +589,5 @@ And please do participate!
 [`explorer.search()`]: #explorersearch
 
 [`explorer.load()`]: #explorerload
+
+["Loading JS modules"]: #loading-js-modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 # http://www.appveyor.com/docs/appveyor-yml
 
-branches:
-  only:
-    - main
-    - v7
+# branches:
+#   only:
+#     - main
+#     - v7
 
 clone_depth: 5
 version: '{build}'

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "format:md": "remark-preset-davidtheclark --format",
     "format:check": "prettier \"**/*.{js,ts,json,yml,yaml}\" --check",
     "typescript": "tsc",
-    "test": "jest --coverage",
-    "test:watch": "jest --watch",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --coverage",
+    "test:watch": "node --experimental-vm-modules node_modules/.bin/jest --watchAll",
     "check:all": "npm run test && npm run typescript && npm run lint && npm run format:check",
     "prepublishOnly": "npm run check:all && npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "tabWidth": 2
   },
   "jest": {
+    "testRunner": "jest-circus/runner",
     "testEnvironment": "node",
     "collectCoverageFrom": [
       "src/**/*.{js,ts}"
@@ -131,7 +132,8 @@
     "eslint-plugin-jest": "^23.18.0",
     "eslint-plugin-node": "^11.1.0",
     "husky": "^4.2.5",
-    "jest": "^26.1.0",
+    "jest": "^26.6.3",
+    "jest-circus": "^26.6.3",
     "lint-staged": "^10.2.11",
     "make-dir": "^3.1.0",
     "parent-module": "^2.0.0",

--- a/src/ExplorerBase.ts
+++ b/src/ExplorerBase.ts
@@ -86,7 +86,7 @@ class ExplorerBase<T extends ExplorerOptions | ExplorerOptionsSync> {
     return nextDir;
   }
 
-  private loadPackageProp(filepath: string, content: string): unknown {
+  private loadPackageProp(filepath: string, content: string | null): unknown {
     const parsedContent = loaders.loadJson(filepath, content);
     const packagePropValue = getPropertyByPath(
       parsedContent,

--- a/src/canUseDynamicImport.ts
+++ b/src/canUseDynamicImport.ts
@@ -1,11 +1,15 @@
-/* istanbul ignore next */
+/* istanbul ignore file */
+let result: boolean;
 function canUseDynamicImport(): boolean {
-  try {
-    new Function('id', 'return import(id);');
-    return true;
-  } catch (e) {
-    return false;
+  if (result === undefined) {
+    try {
+      new Function('id', 'return import(id);');
+      result = true;
+    } catch (e) {
+      result = false;
+    }
   }
+  return result;
 }
 
 export { canUseDynamicImport };

--- a/src/canUseDynamicImport.ts
+++ b/src/canUseDynamicImport.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore next */
+function canUseDynamicImport(): boolean {
+  try {
+    new Function('id', 'return import(id);');
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export { canUseDynamicImport };

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ function cosmiconfigSync(moduleName: string, options: OptionsSync = {}) {
 
 // do not allow mutation of default loaders. Make sure it is set inside options
 const defaultLoaders = Object.freeze({
-  // '.mjs': loaders.loadJs,
+  '.mjs': loaders.loadJs,
   '.cjs': loaders.loadJs,
   '.js': loaders.loadJs,
   '.json': loaders.loadJson,
@@ -121,12 +121,12 @@ function normalizeOptions(
       `.${moduleName}rc.yaml`,
       `.${moduleName}rc.yml`,
       `.${moduleName}rc.js`,
-      // `.${moduleName}rc.mjs`,
+      `.${moduleName}rc.mjs`,
       `.${moduleName}rc.cjs`,
       `${moduleName}.config.js`,
-      // `${moduleName}.config.mjs`,
+      `${moduleName}.config.mjs`,
       `${moduleName}.config.cjs`,
-    ],
+    ].filter(Boolean),
     ignoreEmptySearchPlaces: true,
     stopDir: os.homedir(),
     cache: true,
@@ -182,4 +182,4 @@ function normalizeOptionsSync(
   return normalizedOptions;
 }
 
-export { cosmiconfig, cosmiconfigSync, defaultLoaders };
+export { cosmiconfig, cosmiconfigSync, defaultLoaders, defaultLoadersSync };

--- a/test/failed-directories.test.ts
+++ b/test/failed-directories.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { TempDir } from './util';
+import { TempDir, isNotMjs } from './util';
 import {
   cosmiconfig,
   cosmiconfigSync,
@@ -23,40 +23,53 @@ describe('gives up if it cannot find the file', () => {
   const startDir = temp.absolutePath('a/b');
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
-  const checkResult = (statSpy: any, readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/package.json',
+    'a/b/.foorc',
+    'a/b/.foorc.json',
+    'a/b/.foorc.yaml',
+    'a/b/.foorc.yml',
+    'a/b/.foorc.js',
+    'a/b/.foorc.mjs',
+    'a/b/.foorc.cjs',
+    'a/b/foo.config.js',
+    'a/b/foo.config.mjs',
+    'a/b/foo.config.cjs',
+    'a/package.json',
+    'a/.foorc',
+    'a/.foorc.json',
+    'a/.foorc.yaml',
+    'a/.foorc.yml',
+    'a/.foorc.js',
+    'a/.foorc.mjs',
+    'a/.foorc.cjs',
+    'a/foo.config.js',
+    'a/foo.config.mjs',
+    'a/foo.config.cjs',
+    'package.json',
+    '.foorc',
+    '.foorc.json',
+    '.foorc.yaml',
+    '.foorc.yml',
+    '.foorc.js',
+    '.foorc.mjs',
+    '.foorc.cjs',
+    'foo.config.js',
+    'foo.config.mjs',
+    'foo.config.cjs',
+  ];
+
+  const checkResult = (
+    statSpy: any,
+    readFileSpy: any,
+    result: any,
+    files: any,
+  ) => {
     const statPath = temp.getSpyPathCalls(statSpy);
     expect(statPath).toEqual(['a/b']);
 
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/package.json',
-      'a/b/.foorc',
-      'a/b/.foorc.json',
-      'a/b/.foorc.yaml',
-      'a/b/.foorc.yml',
-      'a/b/.foorc.js',
-      'a/b/.foorc.cjs',
-      'a/b/foo.config.js',
-      'a/b/foo.config.cjs',
-      'a/package.json',
-      'a/.foorc',
-      'a/.foorc.json',
-      'a/.foorc.yaml',
-      'a/.foorc.yml',
-      'a/.foorc.js',
-      'a/.foorc.cjs',
-      'a/foo.config.js',
-      'a/foo.config.cjs',
-      'package.json',
-      '.foorc',
-      '.foorc.json',
-      '.foorc.yaml',
-      '.foorc.yml',
-      '.foorc.js',
-      '.foorc.cjs',
-      'foo.config.js',
-      'foo.config.cjs',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toBe(null);
   };
@@ -66,7 +79,7 @@ describe('gives up if it cannot find the file', () => {
     const statSpy = jest.spyOn(fs, 'stat');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(statSpy, readFileSpy, result);
+    checkResult(statSpy, readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
@@ -74,7 +87,12 @@ describe('gives up if it cannot find the file', () => {
     const statSpy = jest.spyOn(fs, 'statSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(statSpy, readFileSpy, result);
+    checkResult(
+      statSpy,
+      readFileSpy,
+      result,
+      expectedFilesChecked.filter(isNotMjs),
+    );
   });
 });
 
@@ -82,28 +100,34 @@ describe('stops at stopDir and gives up', () => {
   const startDir = temp.absolutePath('a/b');
   const explorerOptions = { stopDir: temp.absolutePath('a') };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/package.json',
+    'a/b/.foorc',
+    'a/b/.foorc.json',
+    'a/b/.foorc.yaml',
+    'a/b/.foorc.yml',
+    'a/b/.foorc.js',
+    'a/b/.foorc.mjs',
+    'a/b/.foorc.cjs',
+    'a/b/foo.config.js',
+    'a/b/foo.config.mjs',
+    'a/b/foo.config.cjs',
+    'a/package.json',
+    'a/.foorc',
+    'a/.foorc.json',
+    'a/.foorc.yaml',
+    'a/.foorc.yml',
+    'a/.foorc.js',
+    'a/.foorc.mjs',
+    'a/.foorc.cjs',
+    'a/foo.config.js',
+    'a/foo.config.mjs',
+    'a/foo.config.cjs',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/package.json',
-      'a/b/.foorc',
-      'a/b/.foorc.json',
-      'a/b/.foorc.yaml',
-      'a/b/.foorc.yml',
-      'a/b/.foorc.js',
-      'a/b/.foorc.cjs',
-      'a/b/foo.config.js',
-      'a/b/foo.config.cjs',
-      'a/package.json',
-      'a/.foorc',
-      'a/.foorc.json',
-      'a/.foorc.yaml',
-      'a/.foorc.yml',
-      'a/.foorc.js',
-      'a/.foorc.cjs',
-      'a/foo.config.js',
-      'a/foo.config.cjs',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toBe(null);
   };
@@ -112,14 +136,14 @@ describe('stops at stopDir and gives up', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -74,21 +74,17 @@ describe('cosmiconfig', () => {
   });
 
   describe('creates explorer with default options if not specified', () => {
-    const checkResult = (mock: jest.SpyInstance) => {
+    const checkResult = (
+      mock: jest.SpyInstance,
+      { expectedLoaders }: { expectedLoaders: { [key: string]: string } },
+    ) => {
       expect(mock.mock.calls.length).toEqual(1);
       expect(mock.mock.calls[0].length).toEqual(1);
 
       const { transform, loaders, ...explorerOptions } = mock.mock.calls[0][0];
       expect(transform.name).toBe('identity');
       const loaderFunctionsByName = getLoaderFunctionsByName(loaders);
-      expect(loaderFunctionsByName).toEqual({
-        '.cjs': 'loadJs',
-        '.js': 'loadJs',
-        '.json': 'loadJson',
-        '.yaml': 'loadYaml',
-        '.yml': 'loadYaml',
-        noExt: 'loadYaml',
-      });
+      expect(loaderFunctionsByName).toEqual(expectedLoaders);
 
       expect(explorerOptions).toEqual({
         packageProp: moduleName,
@@ -111,12 +107,30 @@ describe('cosmiconfig', () => {
 
     test('async', () => {
       cosmiconfig(moduleName);
-      checkResult(createExplorerMock);
+      checkResult(createExplorerMock, {
+        expectedLoaders: {
+          '.cjs': 'loadJs',
+          '.js': 'loadJs',
+          '.json': 'loadJson',
+          '.yaml': 'loadYaml',
+          '.yml': 'loadYaml',
+          noExt: 'loadYaml',
+        },
+      });
     });
 
     test('sync', () => {
       cosmiconfigSync(moduleName);
-      checkResult(createExplorerSyncMock);
+      checkResult(createExplorerSyncMock, {
+        expectedLoaders: {
+          '.cjs': 'loadJsSync',
+          '.js': 'loadJsSync',
+          '.json': 'loadJson',
+          '.yaml': 'loadYaml',
+          '.yml': 'loadYaml',
+          noExt: 'loadYaml',
+        },
+      });
     });
   });
 

--- a/test/successful-directories.test.ts
+++ b/test/successful-directories.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { TempDir } from './util';
+import { TempDir, isNotMjs } from './util';
 import { cosmiconfig, cosmiconfigSync, defaultLoaders } from '../src';
 
 const temp = new TempDir();
@@ -23,30 +23,36 @@ describe('finds rc file in third searched dir, with a package.json lacking prop'
   const startDir = temp.absolutePath('a/b/c/d/e/f');
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.js',
+    'a/b/c/d/e/f/.foorc.mjs',
+    'a/b/c/d/e/f/.foorc.cjs',
+    'a/b/c/d/e/f/foo.config.js',
+    'a/b/c/d/e/f/foo.config.mjs',
+    'a/b/c/d/e/f/foo.config.cjs',
+    'a/b/c/d/e/package.json',
+    'a/b/c/d/e/.foorc',
+    'a/b/c/d/e/.foorc.json',
+    'a/b/c/d/e/.foorc.yaml',
+    'a/b/c/d/e/.foorc.yml',
+    'a/b/c/d/e/.foorc.js',
+    'a/b/c/d/e/.foorc.mjs',
+    'a/b/c/d/e/.foorc.cjs',
+    'a/b/c/d/e/foo.config.js',
+    'a/b/c/d/e/foo.config.mjs',
+    'a/b/c/d/e/foo.config.cjs',
+    'a/b/c/d/package.json',
+    'a/b/c/d/.foorc',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.js',
-      'a/b/c/d/e/f/.foorc.cjs',
-      'a/b/c/d/e/f/foo.config.js',
-      'a/b/c/d/e/f/foo.config.cjs',
-      'a/b/c/d/e/package.json',
-      'a/b/c/d/e/.foorc',
-      'a/b/c/d/e/.foorc.json',
-      'a/b/c/d/e/.foorc.yaml',
-      'a/b/c/d/e/.foorc.yml',
-      'a/b/c/d/e/.foorc.js',
-      'a/b/c/d/e/.foorc.cjs',
-      'a/b/c/d/e/foo.config.js',
-      'a/b/c/d/e/foo.config.cjs',
-      'a/b/c/d/package.json',
-      'a/b/c/d/.foorc',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -58,14 +64,14 @@ describe('finds rc file in third searched dir, with a package.json lacking prop'
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -80,20 +86,24 @@ describe('finds package.json prop in second searched dir', () => {
   const startDir = temp.absolutePath('a/b/c/d/e/f');
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.js',
+    'a/b/c/d/e/f/.foorc.mjs',
+    'a/b/c/d/e/f/.foorc.cjs',
+    'a/b/c/d/e/f/foo.config.js',
+    'a/b/c/d/e/f/foo.config.mjs',
+    'a/b/c/d/e/f/foo.config.cjs',
+    'a/b/c/d/e/package.json',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.js',
-      'a/b/c/d/e/f/.foorc.cjs',
-      'a/b/c/d/e/f/foo.config.js',
-      'a/b/c/d/e/f/foo.config.cjs',
-      'a/b/c/d/e/package.json',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -105,14 +115,14 @@ describe('finds package.json prop in second searched dir', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -135,20 +145,24 @@ describe('finds package.json with nested packageProp in second searched dir', ()
     packageProp: 'configs.pkg',
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.js',
+    'a/b/c/d/e/f/.foorc.mjs',
+    'a/b/c/d/e/f/.foorc.cjs',
+    'a/b/c/d/e/f/foo.config.js',
+    'a/b/c/d/e/f/foo.config.mjs',
+    'a/b/c/d/e/f/foo.config.cjs',
+    'a/b/c/d/e/package.json',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.js',
-      'a/b/c/d/e/f/.foorc.cjs',
-      'a/b/c/d/e/f/foo.config.js',
-      'a/b/c/d/e/f/foo.config.cjs',
-      'a/b/c/d/e/package.json',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { please: 'no' },
@@ -159,13 +173,13 @@ describe('finds package.json with nested packageProp in second searched dir', ()
   test('async', async () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -180,19 +194,22 @@ describe('finds JS file in first searched dir', () => {
   const startDir = temp.absolutePath('a/b/c/d/e/f');
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.js',
+    'a/b/c/d/e/f/.foorc.mjs',
+    'a/b/c/d/e/f/.foorc.cjs',
+    'a/b/c/d/e/f/foo.config.js',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
 
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.js',
-      'a/b/c/d/e/f/.foorc.cjs',
-      'a/b/c/d/e/f/foo.config.js',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -204,14 +221,14 @@ describe('finds JS file in first searched dir', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -226,20 +243,24 @@ describe('finds CJS file in first searched dir', () => {
   const startDir = temp.absolutePath('a/b/c/d/e/f');
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.js',
+    'a/b/c/d/e/f/.foorc.mjs',
+    'a/b/c/d/e/f/.foorc.cjs',
+    'a/b/c/d/e/f/foo.config.js',
+    'a/b/c/d/e/f/foo.config.mjs',
+    'a/b/c/d/e/f/foo.config.cjs',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
 
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.js',
-      'a/b/c/d/e/f/.foorc.cjs',
-      'a/b/c/d/e/f/foo.config.js',
-      'a/b/c/d/e/f/foo.config.cjs',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -251,14 +272,14 @@ describe('finds CJS file in first searched dir', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -273,17 +294,19 @@ describe('finds .foorc.js file in first searched dir', () => {
   const startDir = temp.absolutePath('a/b/c/d/e/f');
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.js',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
 
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.js',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -295,14 +318,14 @@ describe('finds .foorc.js file in first searched dir', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -318,19 +341,22 @@ describe('skips over empty file to find JS file in first searched dir', () => {
   const startDir = temp.absolutePath('a/b/c/d/e/f');
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.js',
+    'a/b/c/d/e/f/.foorc.mjs',
+    'a/b/c/d/e/f/.foorc.cjs',
+    'a/b/c/d/e/f/foo.config.js',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
 
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.js',
-      'a/b/c/d/e/f/.foorc.cjs',
-      'a/b/c/d/e/f/foo.config.js',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -342,14 +368,14 @@ describe('skips over empty file to find JS file in first searched dir', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -365,14 +391,16 @@ describe('finds package.json in second dir searched, with alternate names', () =
     searchPlaces: ['package.json', '.wowza', 'wowzaConfig.js'],
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.wowza',
+    'a/b/c/d/e/f/wowzaConfig.js',
+    'a/b/c/d/e/package.json',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.wowza',
-      'a/b/c/d/e/f/wowzaConfig.js',
-      'a/b/c/d/e/package.json',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -384,14 +412,14 @@ describe('finds package.json in second dir searched, with alternate names', () =
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -409,15 +437,17 @@ describe('finds rc file in third searched dir, skipping packageProp, parsing ext
     searchPlaces: ['.foorc', 'foo.config.js'],
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/foo.config.js',
+    'a/b/c/d/e/.foorc',
+    'a/b/c/d/e/foo.config.js',
+    'a/b/c/d/.foorc',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/foo.config.js',
-      'a/b/c/d/e/.foorc',
-      'a/b/c/d/e/foo.config.js',
-      'a/b/c/d/.foorc',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -429,13 +459,13 @@ describe('finds rc file in third searched dir, skipping packageProp, parsing ext
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -452,12 +482,14 @@ describe('finds package.json file in second searched dir, skipping JS and RC fil
     searchPlaces: ['package.json'],
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/package.json',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/package.json',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -469,14 +501,14 @@ describe('finds package.json file in second searched dir, skipping JS and RC fil
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -490,22 +522,26 @@ describe('finds .foorc.json in second searched dir', () => {
     stopDir: temp.absolutePath('.'),
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.js',
+    'a/b/c/d/e/f/.foorc.mjs',
+    'a/b/c/d/e/f/.foorc.cjs',
+    'a/b/c/d/e/f/foo.config.js',
+    'a/b/c/d/e/f/foo.config.mjs',
+    'a/b/c/d/e/f/foo.config.cjs',
+    'a/b/c/d/e/package.json',
+    'a/b/c/d/e/.foorc',
+    'a/b/c/d/e/.foorc.json',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.js',
-      'a/b/c/d/e/f/.foorc.cjs',
-      'a/b/c/d/e/f/foo.config.js',
-      'a/b/c/d/e/f/foo.config.cjs',
-      'a/b/c/d/e/package.json',
-      'a/b/c/d/e/.foorc',
-      'a/b/c/d/e/.foorc.json',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -517,14 +553,14 @@ describe('finds .foorc.json in second searched dir', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -538,14 +574,16 @@ describe('finds .foorc.yaml in first searched dir', () => {
     stopDir: temp.absolutePath('.'),
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -557,14 +595,14 @@ describe('finds .foorc.yaml in first searched dir', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -578,15 +616,17 @@ describe('finds .foorc.yml in first searched dir', () => {
     stopDir: temp.absolutePath('.'),
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+    'a/b/c/d/e/f/.foorc.yml',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-      'a/b/c/d/e/f/.foorc.yml',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -598,14 +638,14 @@ describe('finds .foorc.yml in first searched dir', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -634,20 +674,22 @@ describe('adding myfooconfig.js to searchPlaces, finds it in first searched dir'
     ],
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.cjs',
+    'a/b/c/d/e/f/foo.config.cjs',
+    'a/b/c/d/e/f/.foorc.js',
+    'a/b/c/d/e/f/foo.config.js',
+    'a/b/c/d/e/f/myfooconfig.js',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.cjs',
-      'a/b/c/d/e/f/foo.config.cjs',
-      'a/b/c/d/e/f/.foorc.js',
-      'a/b/c/d/e/f/foo.config.js',
-      'a/b/c/d/e/f/myfooconfig.js',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -659,13 +701,13 @@ describe('adding myfooconfig.js to searchPlaces, finds it in first searched dir'
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -688,27 +730,32 @@ describe('finds JS file traversing from cwd', () => {
     stopDir: temp.absolutePath('.'),
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yaml',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.js',
+    'a/b/c/d/e/f/.foorc.mjs',
+    'a/b/c/d/e/f/.foorc.cjs',
+    'a/b/c/d/e/f/foo.config.js',
+    'a/b/c/d/e/f/foo.config.mjs',
+    'a/b/c/d/e/f/foo.config.cjs',
+    'a/b/c/d/e/package.json',
+    'a/b/c/d/e/.foorc',
+    'a/b/c/d/e/.foorc.json',
+    'a/b/c/d/e/.foorc.yaml',
+    'a/b/c/d/e/.foorc.yml',
+    'a/b/c/d/e/.foorc.js',
+    'a/b/c/d/e/.foorc.mjs',
+    'a/b/c/d/e/.foorc.cjs',
+    'a/b/c/d/e/foo.config.js',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yaml',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.js',
-      'a/b/c/d/e/f/.foorc.cjs',
-      'a/b/c/d/e/f/foo.config.js',
-      'a/b/c/d/e/f/foo.config.cjs',
-      'a/b/c/d/e/package.json',
-      'a/b/c/d/e/.foorc',
-      'a/b/c/d/e/.foorc.json',
-      'a/b/c/d/e/.foorc.yaml',
-      'a/b/c/d/e/.foorc.yml',
-      'a/b/c/d/e/.foorc.js',
-      'a/b/c/d/e/.foorc.cjs',
-      'a/b/c/d/e/foo.config.js',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -720,14 +767,14 @@ describe('finds JS file traversing from cwd', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search();
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search();
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -747,17 +794,19 @@ describe('searchPlaces can include subdirectories', () => {
     ],
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.config/.foorc.json',
+    'a/b/c/d/e/f/.config/foo/config.json',
+    'a/b/c/d/e/.foorc.json',
+    'a/b/c/d/e/package.json',
+    'a/b/c/d/e/.config/.foorc.json',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.config/.foorc.json',
-      'a/b/c/d/e/f/.config/foo/config.json',
-      'a/b/c/d/e/.foorc.json',
-      'a/b/c/d/e/package.json',
-      'a/b/c/d/e/.config/.foorc.json',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { found: true },
@@ -769,14 +818,14 @@ describe('searchPlaces can include subdirectories', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -812,19 +861,21 @@ describe('custom loaders allow non-default file types', () => {
     },
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.things',
+    'a/b/c/d/e/f/.foorc.grumbly',
+    'a/b/c/d/e/package.json',
+    'a/b/c/d/e/.foorc.json',
+    'a/b/c/d/e/.foorc.yml',
+    'a/b/c/d/e/.foorc.things',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.things',
-      'a/b/c/d/e/f/.foorc.grumbly',
-      'a/b/c/d/e/package.json',
-      'a/b/c/d/e/.foorc.json',
-      'a/b/c/d/e/.foorc.yml',
-      'a/b/c/d/e/.foorc.things',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { things: ['one', 'two', 'three', 'four'] },
@@ -836,14 +887,14 @@ describe('custom loaders allow non-default file types', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -879,19 +930,21 @@ describe('adding custom loaders allows for default and non-default file types', 
     },
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/f/.foorc.things',
+    'a/b/c/d/e/f/.foorc.grumbly',
+    'a/b/c/d/e/package.json',
+    'a/b/c/d/e/.foorc.json',
+    'a/b/c/d/e/.foorc.yml',
+    'a/b/c/d/e/.foorc.things',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/f/.foorc.things',
-      'a/b/c/d/e/f/.foorc.grumbly',
-      'a/b/c/d/e/package.json',
-      'a/b/c/d/e/.foorc.json',
-      'a/b/c/d/e/.foorc.yml',
-      'a/b/c/d/e/.foorc.things',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { things: ['one', 'two', 'three', 'four'] },
@@ -903,14 +956,14 @@ describe('adding custom loaders allows for default and non-default file types', 
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 
@@ -936,19 +989,21 @@ describe('defaults loaders can be overridden', () => {
     },
   };
 
-  const checkResult = (readFileSpy: any, result: any) => {
+  const expectedFilesChecked = [
+    'a/b/c/d/e/f/package.json',
+    'a/b/c/d/e/f/.foorc.json',
+    'a/b/c/d/e/f/foo.config.cjs',
+    'a/b/c/d/e/f/foo.config.js',
+    'a/b/c/d/e/f/.foorc.yml',
+    'a/b/c/d/e/package.json',
+    'a/b/c/d/e/.foorc.json',
+    'a/b/c/d/e/foo.config.cjs',
+    'a/b/c/d/e/foo.config.js',
+  ];
+
+  const checkResult = (readFileSpy: any, result: any, files: any) => {
     const filesChecked = temp.getSpyPathCalls(readFileSpy);
-    expect(filesChecked).toEqual([
-      'a/b/c/d/e/f/package.json',
-      'a/b/c/d/e/f/.foorc.json',
-      'a/b/c/d/e/f/foo.config.cjs',
-      'a/b/c/d/e/f/foo.config.js',
-      'a/b/c/d/e/f/.foorc.yml',
-      'a/b/c/d/e/package.json',
-      'a/b/c/d/e/.foorc.json',
-      'a/b/c/d/e/foo.config.cjs',
-      'a/b/c/d/e/foo.config.js',
-    ]);
+    expect(filesChecked).toEqual(files);
 
     expect(result).toEqual({
       config: { grumbly: true },
@@ -960,14 +1015,14 @@ describe('defaults loaders can be overridden', () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked);
   });
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
     const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
-    checkResult(readFileSpy, result);
+    checkResult(readFileSpy, result, expectedFilesChecked.filter(isNotMjs));
   });
 });
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -71,18 +71,27 @@ class TempDir {
   public getSpyPathCalls(spy: jest.Mock | jest.SpyInstance): Array<string> {
     const calls = spy.mock.calls;
 
-    const result = calls.map((call): string => {
-      const filePath = call[0];
-      const relativePath = path.relative(this.dir, filePath);
+    const result = calls
+      .filter((call): boolean => {
+        /**
+         * Filter out `fs` calls that are made within cosmiconfig's dependency
+         * tree.
+         */
+        const filePath = call[0];
+        return !filePath.includes('/cosmiconfig/node_modules/');
+      })
+      .map((call): string => {
+        const filePath = call[0];
+        const relativePath = path.relative(this.dir, filePath);
 
-      /**
-       * Replace Windows backslash directory separators with forward slashes
-       * so expected paths will be consistent cross platform
-       */
-      const normalizeCrossPlatform = normalizeDirectorySlash(relativePath);
+        /**
+         * Replace Windows backslash directory separators with forward slashes
+         * so expected paths will be consistent cross platform
+         */
+        const normalizeCrossPlatform = normalizeDirectorySlash(relativePath);
 
-      return normalizeCrossPlatform;
-    });
+        return normalizeCrossPlatform;
+      });
 
     return result;
   }

--- a/test/util.ts
+++ b/test/util.ts
@@ -72,14 +72,6 @@ class TempDir {
     const calls = spy.mock.calls;
 
     const result = calls
-      .filter((call): boolean => {
-        /**
-         * Filter out `fs` calls that are made within cosmiconfig's dependency
-         * tree.
-         */
-        const filePath = call[0];
-        return !filePath.includes('/cosmiconfig/node_modules/');
-      })
       .map((call): string => {
         const filePath = call[0];
         const relativePath = path.relative(this.dir, filePath);
@@ -91,6 +83,13 @@ class TempDir {
         const normalizeCrossPlatform = normalizeDirectorySlash(relativePath);
 
         return normalizeCrossPlatform;
+      })
+      .filter((filePath): boolean => {
+        /**
+         * Filter out `fs` calls that are made within cosmiconfig's dependency
+         * tree.
+         */
+        return !filePath.includes('/cosmiconfig/node_modules/');
       });
 
     return result;

--- a/test/util.ts
+++ b/test/util.ts
@@ -115,4 +115,8 @@ class TempDir {
   }
 }
 
-export { TempDir };
+function isNotMjs(filePath: string): boolean {
+  return path.extname(filePath) !== '.mjs';
+}
+
+export { TempDir, isNotMjs };


### PR DESCRIPTION
This PR intends to close https://github.com/davidtheclark/cosmiconfig/issues/224. I don't have more time to work on this today so I'll get what I have up as a draft — feedback welcome! **I'd especially appreciate help testing this from people interested in using ESM,** both ensuring that it works as expected and ensuring that the expectations are the right ones.

Some notes:

- ESM is only supported by the asynchronous API, because it is enabled by the asynchronous `import()` function.
- So `.mjs` is only added to the default `searchPlaces` of the asynchronous API.
- I turned off the selective branches in CI configuration because I wasn't seeing tests run. It may be that Travis and Appveyor needed to catch up with the main branch name change (from `master` to `main`). We'll see.
- I was having some trouble early on with Jest, so tried using the `jest-circus` test runner. Turns out that wasn't the problem at all, but I left in that update.
- This PR is set to merge into a `v8` branch, in case there's anything else in the issue queue that anybody wants to get into v8.