### PR TITLE
Add support for [name].config.json by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ By default, Cosmiconfig will start where you tell it to start and search up the 
 - a JSON or YAML, extensionless "rc file"
 - an "rc file" with the extensions `.json`, `.yaml`, `.yml`, `.js`, or `.cjs`
 - a `.config.js` or `.config.cjs` CommonJS module
+- a `.config.json` file in JSON format
 
 For example, if your module's name is "myapp", cosmiconfig will search up the directory tree for configuration in the following places:
 
@@ -21,6 +22,7 @@ For example, if your module's name is "myapp", cosmiconfig will search up the di
 - a `.myapprc` file in JSON or YAML format
 - a `.myapprc.json`, `.myapprc.yaml`, `.myapprc.yml`, `.myapprc.js`, or `.myapprc.cjs` file
 - a `myapp.config.js` or `myapp.config.cjs` CommonJS module exporting an object
+- a `myapp.config.json` file in JSON format
 
 Cosmiconfig continues to search up the directory tree, checking each of these places in each directory, until it finds some acceptable configuration (or hits the home directory).
 
@@ -144,6 +146,7 @@ Here's how your default [`search()`] will work:
   2. A `.goldengrahamsrc` file with JSON or YAML syntax.
   3. A `.goldengrahamsrc.json`, `.goldengrahamsrc.yaml`, `.goldengrahamsrc.yml`, `.goldengrahamsrc.js`, or `.goldengrahamsrc.cjs` file.
   4. A `goldengrahams.config.js` or `goldengrahams.config.cjs` CommonJS module exporting the object.
+  5. A `goldengrahams.config.json` file with JSON syntax.
 - If none of those searches reveal a configuration object, move up one directory level and try again.
   So the search continues in `./`, `../`, `../../`, `../../../`, etc., checking the same places in each directory.
 - Continue searching until arriving at your home directory (or some other directory defined by the cosmiconfig option [`stopDir`]).
@@ -269,6 +272,7 @@ Each place is relative to the directory being searched, and the places are check
   `.${moduleName}rc.cjs`,
   `${moduleName}.config.js`,
   `${moduleName}.config.cjs`,
+  `${moduleName}.config.json`,
 ]
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,7 @@ function normalizeOptions(
       `.${moduleName}rc.cjs`,
       `${moduleName}.config.js`,
       `${moduleName}.config.cjs`,
+      `${moduleName}.config.json`,
     ],
     ignoreEmptySearchPlaces: true,
     stopDir: os.homedir(),

--- a/test/caches.test.ts
+++ b/test/caches.test.ts
@@ -35,6 +35,7 @@ describe('cache is not used initially', () => {
       'a/b/c/d/e/.foorc.cjs',
       'a/b/c/d/e/foo.config.js',
       'a/b/c/d/e/foo.config.cjs',
+      'a/b/c/d/e/foo.config.json',
       'a/b/c/d/package.json',
       'a/b/c/d/.foorc',
     ]);
@@ -147,6 +148,7 @@ describe('cache is used when some directories in search are already visted', () 
       'a/b/c/d/e/f/.foorc.cjs',
       'a/b/c/d/e/f/foo.config.js',
       'a/b/c/d/e/f/foo.config.cjs',
+      'a/b/c/d/e/f/foo.config.json',
     ]);
 
     expect(result).toEqual({
@@ -231,6 +233,7 @@ describe('cache is not used in a new cosmiconfig instance', () => {
       'a/b/c/d/e/.foorc.cjs',
       'a/b/c/d/e/foo.config.js',
       'a/b/c/d/e/foo.config.cjs',
+      'a/b/c/d/e/foo.config.json',
       'a/b/c/d/package.json',
       'a/b/c/d/.foorc',
     ]);
@@ -349,6 +352,7 @@ describe('clears directory cache on calling clearSearchCache', () => {
       'a/b/c/d/e/.foorc.cjs',
       'a/b/c/d/e/foo.config.js',
       'a/b/c/d/e/foo.config.cjs',
+      'a/b/c/d/e/foo.config.json',
       'a/b/c/d/package.json',
       'a/b/c/d/.foorc',
     ]);
@@ -397,6 +401,7 @@ describe('clears directory cache on calling clearCaches', () => {
       'a/b/c/d/e/.foorc.cjs',
       'a/b/c/d/e/foo.config.js',
       'a/b/c/d/e/foo.config.cjs',
+      'a/b/c/d/e/foo.config.json',
       'a/b/c/d/package.json',
       'a/b/c/d/.foorc',
     ]);
@@ -461,6 +466,7 @@ describe('with cache disabled, does not cache directory results', () => {
       'a/b/c/d/e/.foorc.cjs',
       'a/b/c/d/e/foo.config.js',
       'a/b/c/d/e/foo.config.cjs',
+      'a/b/c/d/e/foo.config.json',
       'a/b/c/d/package.json',
       'a/b/c/d/.foorc',
     ]);

--- a/test/failed-directories.test.ts
+++ b/test/failed-directories.test.ts
@@ -38,6 +38,7 @@ describe('gives up if it cannot find the file', () => {
       'a/b/.foorc.cjs',
       'a/b/foo.config.js',
       'a/b/foo.config.cjs',
+      'a/b/foo.config.json',
       'a/package.json',
       'a/.foorc',
       'a/.foorc.json',
@@ -47,6 +48,7 @@ describe('gives up if it cannot find the file', () => {
       'a/.foorc.cjs',
       'a/foo.config.js',
       'a/foo.config.cjs',
+      'a/foo.config.json',
       'package.json',
       '.foorc',
       '.foorc.json',
@@ -56,6 +58,7 @@ describe('gives up if it cannot find the file', () => {
       '.foorc.cjs',
       'foo.config.js',
       'foo.config.cjs',
+      'foo.config.json',
     ]);
 
     expect(result).toBe(null);
@@ -94,6 +97,7 @@ describe('stops at stopDir and gives up', () => {
       'a/b/.foorc.cjs',
       'a/b/foo.config.js',
       'a/b/foo.config.cjs',
+      'a/b/foo.config.json',
       'a/package.json',
       'a/.foorc',
       'a/.foorc.json',
@@ -103,6 +107,7 @@ describe('stops at stopDir and gives up', () => {
       'a/.foorc.cjs',
       'a/foo.config.js',
       'a/foo.config.cjs',
+      'a/foo.config.json',
     ]);
 
     expect(result).toBe(null);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -102,6 +102,7 @@ describe('cosmiconfig', () => {
           `.${moduleName}rc.cjs`,
           `${moduleName}.config.js`,
           `${moduleName}.config.cjs`,
+          `${moduleName}.config.json`,
         ],
         ignoreEmptySearchPlaces: true,
         stopDir: os.homedir(),

--- a/test/successful-directories.test.ts
+++ b/test/successful-directories.test.ts
@@ -35,6 +35,7 @@ describe('finds rc file in third searched dir, with a package.json lacking prop'
       'a/b/c/d/e/f/.foorc.cjs',
       'a/b/c/d/e/f/foo.config.js',
       'a/b/c/d/e/f/foo.config.cjs',
+      'a/b/c/d/e/f/foo.config.json',
       'a/b/c/d/e/package.json',
       'a/b/c/d/e/.foorc',
       'a/b/c/d/e/.foorc.json',
@@ -44,6 +45,7 @@ describe('finds rc file in third searched dir, with a package.json lacking prop'
       'a/b/c/d/e/.foorc.cjs',
       'a/b/c/d/e/foo.config.js',
       'a/b/c/d/e/foo.config.cjs',
+      'a/b/c/d/e/foo.config.json',
       'a/b/c/d/package.json',
       'a/b/c/d/.foorc',
     ]);
@@ -92,6 +94,7 @@ describe('finds package.json prop in second searched dir', () => {
       'a/b/c/d/e/f/.foorc.cjs',
       'a/b/c/d/e/f/foo.config.js',
       'a/b/c/d/e/f/foo.config.cjs',
+      'a/b/c/d/e/f/foo.config.json',
       'a/b/c/d/e/package.json',
     ]);
 
@@ -147,6 +150,7 @@ describe('finds package.json with nested packageProp in second searched dir', ()
       'a/b/c/d/e/f/.foorc.cjs',
       'a/b/c/d/e/f/foo.config.js',
       'a/b/c/d/e/f/foo.config.cjs',
+      'a/b/c/d/e/f/foo.config.json',
       'a/b/c/d/e/package.json',
     ]);
 
@@ -244,6 +248,51 @@ describe('finds CJS file in first searched dir', () => {
     expect(result).toEqual({
       config: { found: true },
       filepath: temp.absolutePath('a/b/c/d/e/f/foo.config.cjs'),
+    });
+  };
+
+  test('async', async () => {
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+
+    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    checkResult(readFileSpy, result);
+  });
+
+  test('sync', () => {
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    checkResult(readFileSpy, result);
+  });
+});
+
+describe('finds JSON file in first searched dir', () => {
+  beforeEach(() => {
+    temp.createFile('a/b/c/d/e/f/foo.config.json', '{ "found": true }');
+  });
+
+  const startDir = temp.absolutePath('a/b/c/d/e/f');
+  const explorerOptions = { stopDir: temp.absolutePath('.') };
+
+  const checkResult = (readFileSpy: any, result: any) => {
+    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+
+    expect(filesChecked).toEqual([
+      'a/b/c/d/e/f/package.json',
+      'a/b/c/d/e/f/.foorc',
+      'a/b/c/d/e/f/.foorc.json',
+      'a/b/c/d/e/f/.foorc.yaml',
+      'a/b/c/d/e/f/.foorc.yml',
+      'a/b/c/d/e/f/.foorc.js',
+      'a/b/c/d/e/f/.foorc.cjs',
+      'a/b/c/d/e/f/foo.config.js',
+      'a/b/c/d/e/f/foo.config.cjs',
+      'a/b/c/d/e/f/foo.config.json',
+    ]);
+
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: temp.absolutePath('a/b/c/d/e/f/foo.config.json'),
     });
   };
 
@@ -502,6 +551,7 @@ describe('finds .foorc.json in second searched dir', () => {
       'a/b/c/d/e/f/.foorc.cjs',
       'a/b/c/d/e/f/foo.config.js',
       'a/b/c/d/e/f/foo.config.cjs',
+      'a/b/c/d/e/f/foo.config.json',
       'a/b/c/d/e/package.json',
       'a/b/c/d/e/.foorc',
       'a/b/c/d/e/.foorc.json',
@@ -628,6 +678,7 @@ describe('adding myfooconfig.js to searchPlaces, finds it in first searched dir'
       '.foorc.yml',
       '.foorc.cjs',
       'foo.config.cjs',
+      'foo.config.json',
       '.foorc.js',
       'foo.config.js',
       'myfooconfig.js',
@@ -644,6 +695,7 @@ describe('adding myfooconfig.js to searchPlaces, finds it in first searched dir'
       'a/b/c/d/e/f/.foorc.yml',
       'a/b/c/d/e/f/.foorc.cjs',
       'a/b/c/d/e/f/foo.config.cjs',
+      'a/b/c/d/e/f/foo.config.json',
       'a/b/c/d/e/f/.foorc.js',
       'a/b/c/d/e/f/foo.config.js',
       'a/b/c/d/e/f/myfooconfig.js',
@@ -700,6 +752,7 @@ describe('finds JS file traversing from cwd', () => {
       'a/b/c/d/e/f/.foorc.cjs',
       'a/b/c/d/e/f/foo.config.js',
       'a/b/c/d/e/f/foo.config.cjs',
+      'a/b/c/d/e/f/foo.config.json',
       'a/b/c/d/e/package.json',
       'a/b/c/d/e/.foorc',
       'a/b/c/d/e/.foorc.json',


### PR DESCRIPTION
This PR is meant to close #246.
It adds default support for `.config.json` files, which is quite common with popular tools like [Babel](https://babeljs.io/docs/en/configuration#whats-your-use-case), [Jest](https://jestjs.io/fr/docs/configuration) or [Metro](https://facebook.github.io/metro/docs/configuration/), among others.