### PR TITLE
Give back some power to the end users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 8.1.0
+
+- Added: always look at `.config.{yml,yaml,json,js,cjs}` file to configure cosmiconfig itself, and look for tool configuration in it using `packageProp` (similar to package.json)
+  - For more info on this, look at the [end user configuration section of the README](README.md#usage-for-end-users)
+
 ## 8.0.0
 
 **No major breaking changes!** We dropped support for Node 10 and 12 -- which you're probably not using. And we swapped out the YAML parser -- which you probably won't notice.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Tested in Node 14+.
 
 ## Usage for tooling developers
 
-*If you are an end user (i.e. a user of a tool that uses cosmiconfig),
+*If you are an end user (i.e. a user of a tool that uses cosmiconfig, like `prettier` or `stylelint`),
 you can skip down to [the end user section](#usage-for-end-users).*
 
 Create a Cosmiconfig explorer, then either `search` for or directly `load` a configuration file.

--- a/README.md
+++ b/README.md
@@ -607,8 +607,7 @@ The following property is currently actively supported in these places:
 
 ```yaml
 cosmiconfig:
-  # overrides where configuration files are being searched to enforce a common naming convention and format
-  # (which are defined by yourself)
+  # overrides where configuration files are being searched to enforce a custom naming convention and format
   searchPlaces:
     - .config/{name}.yml
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Cosmiconfig continues to search up the directory tree, checking each of these pl
 ## Table of contents
 
 - [Installation](#installation)
-- [Usage](#usage)
+- [Usage for tooling developers](#usage-for-tooling-developers)
 - [Result](#result)
 - [Asynchronous API](#asynchronous-api)
   - [cosmiconfig()](#cosmiconfig-1)
@@ -56,6 +56,7 @@ Cosmiconfig continues to search up the directory tree, checking each of these pl
   - [ignoreEmptySearchPlaces](#ignoreemptysearchplaces)
 - [Caching](#caching)
 - [Differences from rc](#differences-from-rc)
+- [Usage for end users](#usage-for-end-users)
 - [Contributing & Development](#contributing--development)
 
 ## Installation
@@ -66,7 +67,10 @@ npm install cosmiconfig
 
 Tested in Node 14+.
 
-## Usage
+## Usage for tooling developers
+
+*If you are an end user (i.e. a user of a tool that uses cosmiconfig),
+you can skip down to [the end user section](#usage-for-end-users).*
 
 Create a Cosmiconfig explorer, then either `search` for or directly `load` a configuration file.
 
@@ -538,6 +542,97 @@ To avoid or work around caching, you can do the following:
 - Stops at the first configuration found, instead of finding all that can be found up the directory tree and merging them automatically.
 - Options.
 - Asynchronous by default (though can be run synchronously).
+
+## Usage for end users
+
+When configuring a tool, you can use multiple file formats and put these in multiple places.
+
+Usually, a tool would mention this in its own README file,
+but by default, these are the following places, where the `moduleName` variable represents the name of the tool:
+
+```js
+[
+  'package.json',
+  `.${moduleName}rc`,
+  `.${moduleName}rc.json`,
+  `.${moduleName}rc.yaml`,
+  `.${moduleName}rc.yml`,
+  `.${moduleName}rc.js`,
+  `.${moduleName}rc.cjs`,
+  `.config/${moduleName}rc`,
+  `.config/${moduleName}rc.json`,
+  `.config/${moduleName}rc.yaml`,
+  `.config/${moduleName}rc.yml`,
+  `.config/${moduleName}rc.js`,
+  `.config/${moduleName}rc.cjs`,
+  `${moduleName}.config.js`,
+  `${moduleName}.config.cjs`,
+]
+```
+
+The contents of these files are defined by the tool.
+For example, you can configure prettier to enforce semicolons at the end of the line
+using a file named `.config/prettierrc.yml`:
+
+```yaml
+semi: true
+```
+
+Additionally, you have the option to put a property named after the tool in your `package.json` file,
+with the contents of that property being the same as the file contents. To use the same example as above:
+
+```json
+{
+  "name": "your-project",
+  "dependencies": {},
+  "prettier": {
+    "semi": true
+  }
+}
+```
+
+This has the advantage that you can put the configuration of all tools
+(at least the ones that use cosmiconfig) in one file.
+
+Lastly, you can also create one of the following files:
+
+```
+.config.json
+.config.yaml
+.config.yml
+.config.js
+.config.cjs
+```
+
+In this file, you can configure `cosmiconfig` itself.
+
+The following properties are currently actively supported in this file:
+
+```yaml
+cosmiconfig:
+  # overrides where configuration files are being searched, this might be a minor performance optimization
+  # if all your configuration files use the same naming convention and format
+  searchPlaces:
+    - .config/{name}.yml
+      
+  # enables configuration resolution in this same file, similarly to `package.json`, see below
+  searchInThisFile: true
+```
+
+> **Note:** technically, you can overwrite all options described in [cosmiconfigOptions](#cosmiconfigoptions) here,
+> but everything not listed above should be used at your own risk, as it has not been tested explicitly.
+
+When enabling `searchInThisFile`, you can also add more root properties outside the `cosmiconfig` property
+to configure your tools, entirely eliminating the need to look for additional configuration files:
+
+```yaml
+cosmiconfig:
+  searchInThisFile: true
+  searchPlaces: []
+
+prettier:
+  semi: true
+```
 
 ## Contributing & Development
 

--- a/README.md
+++ b/README.md
@@ -594,7 +594,8 @@ with the contents of that property being the same as the file contents. To use t
 This has the advantage that you can put the configuration of all tools
 (at least the ones that use cosmiconfig) in one file.
 
-Lastly, you can also create one of the following files:
+You can also add a `cosmiconfig` key within your `package.json` file or create one of the following files
+to configure `cosmiconfig` itself:
 
 ```
 .config.json
@@ -604,9 +605,7 @@ Lastly, you can also create one of the following files:
 .config.cjs
 ```
 
-In this file, you can configure `cosmiconfig` itself.
-
-The following properties are currently actively supported in this file:
+The following properties are currently actively supported in these places:
 
 ```yaml
 cosmiconfig:

--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ to configure `cosmiconfig` itself:
 .config.cjs
 ```
 
-The following properties are currently actively supported in these places:
+The following property is currently actively supported in these places:
 
 ```yaml
 cosmiconfig:
@@ -611,20 +611,16 @@ cosmiconfig:
   # if all your configuration files use the same naming convention and format (defined by yourself)
   searchPlaces:
     - .config/{name}.yml
-      
-  # enables configuration resolution in this same file, similarly to `package.json`, see below
-  searchInThisFile: true
 ```
 
 > **Note:** technically, you can overwrite all options described in [cosmiconfigOptions](#cosmiconfigoptions) here,
 > but everything not listed above should be used at your own risk, as it has not been tested explicitly.
 
-When enabling `searchInThisFile`, you can also add more root properties outside the `cosmiconfig` property
+You can also add more root properties outside the `cosmiconfig` property
 to configure your tools, entirely eliminating the need to look for additional configuration files:
 
 ```yaml
 cosmiconfig:
-  searchInThisFile: true
   searchPlaces: []
 
 prettier:

--- a/README.md
+++ b/README.md
@@ -607,8 +607,8 @@ The following property is currently actively supported in these places:
 
 ```yaml
 cosmiconfig:
-  # overrides where configuration files are being searched, this might be a minor performance optimization
-  # if all your configuration files use the same naming convention and format (defined by yourself)
+  # overrides where configuration files are being searched to enforce a common naming convention and format
+  # (which are defined by yourself)
   searchPlaces:
     - .config/{name}.yml
 ```

--- a/README.md
+++ b/README.md
@@ -548,26 +548,24 @@ To avoid or work around caching, you can do the following:
 When configuring a tool, you can use multiple file formats and put these in multiple places.
 
 Usually, a tool would mention this in its own README file,
-but by default, these are the following places, where the `moduleName` variable represents the name of the tool:
+but by default, these are the following places, where `{NAME}` represents the name of the tool:
 
-```js
-[
-  'package.json',
-  `.${moduleName}rc`,
-  `.${moduleName}rc.json`,
-  `.${moduleName}rc.yaml`,
-  `.${moduleName}rc.yml`,
-  `.${moduleName}rc.js`,
-  `.${moduleName}rc.cjs`,
-  `.config/${moduleName}rc`,
-  `.config/${moduleName}rc.json`,
-  `.config/${moduleName}rc.yaml`,
-  `.config/${moduleName}rc.yml`,
-  `.config/${moduleName}rc.js`,
-  `.config/${moduleName}rc.cjs`,
-  `${moduleName}.config.js`,
-  `${moduleName}.config.cjs`,
-]
+```
+package.json
+.{NAME}rc
+.{NAME}rc.json
+.{NAME}rc.yaml
+.{NAME}rc.yml
+.{NAME}rc.js
+.{NAME}rc.cjs
+.config/{NAME}rc
+.config/{NAME}rc.json
+.config/{NAME}rc.yaml
+.config/{NAME}rc.yml
+.config/{NAME}rc.js
+.config/{NAME}rc.cjs
+{NAME}.config.js
+{NAME}.config.cjs
 ```
 
 The contents of these files are defined by the tool.
@@ -610,7 +608,7 @@ The following properties are currently actively supported in these places:
 ```yaml
 cosmiconfig:
   # overrides where configuration files are being searched, this might be a minor performance optimization
-  # if all your configuration files use the same naming convention and format
+  # if all your configuration files use the same naming convention and format (defined by yourself)
   searchPlaces:
     - .config/{name}.yml
       

--- a/src/Explorer.ts
+++ b/src/Explorer.ts
@@ -13,10 +13,7 @@ class Explorer extends ExplorerBase<ExplorerOptions> {
   public async search(
     searchFrom: string = process.cwd(),
   ): Promise<CosmiconfigResult> {
-    const startDirectory = await getDirectory(searchFrom);
-    const result = await this.searchFromDirectory(startDirectory);
-
-    return result;
+    return await this.searchFromDirectory(await getDirectory(searchFrom));
   }
 
   private async searchFromDirectory(dir: string): Promise<CosmiconfigResult> {
@@ -30,9 +27,7 @@ class Explorer extends ExplorerBase<ExplorerOptions> {
         return this.searchFromDirectory(nextDir);
       }
 
-      const transformResult = await this.config.transform(result);
-
-      return transformResult;
+      return await this.config.transform(result);
     };
 
     if (this.searchCache) {
@@ -46,7 +41,7 @@ class Explorer extends ExplorerBase<ExplorerOptions> {
     for await (const place of this.config.searchPlaces) {
       const placeResult = await this.loadSearchPlace(dir, place);
 
-      if (this.shouldSearchStopWithResult(placeResult) === true) {
+      if (this.shouldSearchStopWithResult(placeResult)) {
         return placeResult;
       }
     }
@@ -62,9 +57,7 @@ class Explorer extends ExplorerBase<ExplorerOptions> {
     const filepath = path.join(dir, place);
     const fileContents = await readFile(filepath);
 
-    const result = await this.createCosmiconfigResult(filepath, fileContents);
-
-    return result;
+    return await this.createCosmiconfigResult(filepath, fileContents);
   }
 
   private async loadFileContent(
@@ -91,9 +84,8 @@ class Explorer extends ExplorerBase<ExplorerOptions> {
     content: string | null,
   ): Promise<CosmiconfigResult> {
     const fileContent = await this.loadFileContent(filepath, content);
-    const result = this.loadedContentToCosmiconfigResult(filepath, fileContent);
 
-    return result;
+    return this.loadedContentToCosmiconfigResult(filepath, fileContent);
   }
 
   public async load(filepath: string): Promise<CosmiconfigResult> {
@@ -110,9 +102,7 @@ class Explorer extends ExplorerBase<ExplorerOptions> {
         fileContents,
       );
 
-      const transformResult = await this.config.transform(result);
-
-      return transformResult;
+      return await this.config.transform(result);
     };
 
     if (this.loadCache) {

--- a/src/Explorer.ts
+++ b/src/Explorer.ts
@@ -13,9 +13,9 @@ class Explorer extends ExplorerBase<ExplorerOptions> {
   public async search(
     searchFrom: string = process.cwd(),
   ): Promise<CosmiconfigResult> {
-    if (this.config.searchInThisFile && this.config.metaConfigFilePath) {
+    if (this.config.metaConfigFilePath) {
       const config = await this._loadFile(this.config.metaConfigFilePath, true);
-      if (this.shouldSearchStopWithResult(config)) {
+      if (config && !config.isEmpty) {
         return config;
       }
     }

--- a/src/ExplorerBase.ts
+++ b/src/ExplorerBase.ts
@@ -115,6 +115,7 @@ class ExplorerBase<T extends ExplorerOptions | ExplorerOptionsSync> {
   protected loadedContentToCosmiconfigResult(
     filepath: string,
     loadedContent: LoadedFileContent,
+    forceProp: boolean,
   ): CosmiconfigResult {
     if (loadedContent === null) {
       return null;
@@ -122,7 +123,7 @@ class ExplorerBase<T extends ExplorerOptions | ExplorerOptionsSync> {
     if (loadedContent === undefined) {
       return { filepath, config: undefined, isEmpty: true };
     }
-    if (this.config.usePackagePropInConfigFiles) {
+    if (this.config.usePackagePropInConfigFiles || forceProp) {
       loadedContent = getPropertyByPath(loadedContent, this.config.packageProp);
     }
     if (loadedContent === undefined) {

--- a/src/ExplorerSync.ts
+++ b/src/ExplorerSync.ts
@@ -15,9 +15,9 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
   }
 
   public searchSync(searchFrom: string = process.cwd()): CosmiconfigResult {
-    if (this.config.searchInThisFile && this.config.metaConfigFilePath) {
+    if (this.config.metaConfigFilePath) {
       const config = this._loadFileSync(this.config.metaConfigFilePath, true);
-      if (this.shouldSearchStopWithResult(config)) {
+      if (config && !config.isEmpty) {
         return config;
       }
     }

--- a/src/ExplorerSync.ts
+++ b/src/ExplorerSync.ts
@@ -15,10 +15,7 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
   }
 
   public searchSync(searchFrom: string = process.cwd()): CosmiconfigResult {
-    const startDirectory = getDirectorySync(searchFrom);
-    const result = this.searchFromDirectorySync(startDirectory);
-
-    return result;
+    return this.searchFromDirectorySync(getDirectorySync(searchFrom));
   }
 
   private searchFromDirectorySync(dir: string): CosmiconfigResult {
@@ -32,9 +29,7 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
         return this.searchFromDirectorySync(nextDir);
       }
 
-      const transformResult = this.config.transform(result);
-
-      return transformResult;
+      return this.config.transform(result);
     };
 
     if (this.searchCache) {
@@ -48,7 +43,7 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
     for (const place of this.config.searchPlaces) {
       const placeResult = this.loadSearchPlaceSync(dir, place);
 
-      if (this.shouldSearchStopWithResult(placeResult) === true) {
+      if (this.shouldSearchStopWithResult(placeResult)) {
         return placeResult;
       }
     }
@@ -61,9 +56,7 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
     const filepath = path.join(dir, place);
     const content = readFileSync(filepath);
 
-    const result = this.createCosmiconfigResultSync(filepath, content);
-
-    return result;
+    return this.createCosmiconfigResultSync(filepath, content);
   }
 
   private loadFileContentSync(
@@ -90,9 +83,8 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
     content: string | null,
   ): CosmiconfigResult {
     const fileContent = this.loadFileContentSync(filepath, content);
-    const result = this.loadedContentToCosmiconfigResult(filepath, fileContent);
 
-    return result;
+    return this.loadedContentToCosmiconfigResult(filepath, fileContent);
   }
 
   public loadSync(filepath: string): CosmiconfigResult {
@@ -106,9 +98,7 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
         content,
       );
 
-      const transformResult = this.config.transform(cosmiconfigResult);
-
-      return transformResult;
+      return this.config.transform(cosmiconfigResult);
     };
 
     if (this.loadCache) {

--- a/src/ExplorerSync.ts
+++ b/src/ExplorerSync.ts
@@ -15,6 +15,12 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
   }
 
   public searchSync(searchFrom: string = process.cwd()): CosmiconfigResult {
+    if (this.config.searchInThisFile && this.config.metaConfigFilePath) {
+      const config = this._loadFileSync(this.config.metaConfigFilePath, true);
+      if (this.shouldSearchStopWithResult(config)) {
+        return config;
+      }
+    }
     return this.searchFromDirectorySync(getDirectorySync(searchFrom));
   }
 
@@ -56,7 +62,7 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
     const filepath = path.join(dir, place);
     const content = readFileSync(filepath);
 
-    return this.createCosmiconfigResultSync(filepath, content);
+    return this.createCosmiconfigResultSync(filepath, content, false);
   }
 
   private loadFileContentSync(
@@ -81,13 +87,25 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
   private createCosmiconfigResultSync(
     filepath: string,
     content: string | null,
+    forceProp: boolean,
   ): CosmiconfigResult {
     const fileContent = this.loadFileContentSync(filepath, content);
 
-    return this.loadedContentToCosmiconfigResult(filepath, fileContent);
+    return this.loadedContentToCosmiconfigResult(
+      filepath,
+      fileContent,
+      forceProp,
+    );
   }
 
   public loadSync(filepath: string): CosmiconfigResult {
+    return this._loadFileSync(filepath, false);
+  }
+
+  private _loadFileSync(
+    filepath: string,
+    forceProp: boolean,
+  ): CosmiconfigResult {
     this.validateFilePath(filepath);
     const absoluteFilePath = path.resolve(process.cwd(), filepath);
 
@@ -96,6 +114,7 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
       const cosmiconfigResult = this.createCosmiconfigResultSync(
         absoluteFilePath,
         content,
+        forceProp,
       );
 
       return this.config.transform(cosmiconfigResult);

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,10 @@ function getExplorerOptions(
 
   const config = metaConfig.config;
 
+  if (config.loaders) {
+    throw new Error('Can not specify loaders in meta config file');
+  }
+
   if (config.searchPlaces) {
     config.searchPlaces = replaceMetaPlaceholders(
       config.searchPlaces,

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,6 @@ export type TransformSync = (
 interface OptionsBase {
   packageProp?: string | Array<string>;
   searchPlaces?: Array<string>;
-  searchInThisFile?: boolean;
   ignoreEmptySearchPlaces?: boolean;
   stopDir?: string;
   cache?: boolean;
@@ -108,8 +107,7 @@ function getExplorerOptions(
     packageProp: 'cosmiconfig',
     stopDir: process.cwd(),
     searchPlaces: metaSearchPlaces,
-    searchInThisFile: false,
-    ignoreEmptySearchPlaces: true,
+    ignoreEmptySearchPlaces: false,
     usePackagePropInConfigFiles: true,
     loaders: defaultLoaders,
     transform: identity,
@@ -122,7 +120,7 @@ function getExplorerOptions(
     return normalizeOptions(moduleName, options);
   }
 
-  const config = metaConfig.config;
+  const config = metaConfig.config ?? {};
 
   if (config.loaders) {
     throw new Error('Can not specify loaders in meta config file');
@@ -220,7 +218,6 @@ function normalizeOptions(
     cache: true,
     transform: identity,
     loaders: defaultLoaders,
-    searchInThisFile: false,
     metaConfigFilePath: null,
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type CosmiconfigResult = {
 
 export interface InternalOptions {
   usePackagePropInConfigFiles?: boolean;
+  metaConfigFilePath: string | null;
 }
 
 // These are the user options with defaults applied, plus internal options possibly inferred from meta config

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,11 +9,15 @@ export type CosmiconfigResult = {
   isEmpty?: boolean;
 } | null;
 
-// These are the user options with defaults applied.
-/* eslint-disable @typescript-eslint/no-empty-interface */
-export interface ExplorerOptions extends Required<Options> {}
-export interface ExplorerOptionsSync extends Required<OptionsSync> {}
-/* eslint-enable @typescript-eslint/no-empty-interface */
+export interface InternalOptions {
+  usePackagePropInConfigFiles?: boolean;
+}
+
+// These are the user options with defaults applied, plus internal options possibly inferred from meta config
+export interface ExplorerOptions extends Required<Options>, InternalOptions {}
+export interface ExplorerOptionsSync
+  extends Required<OptionsSync>,
+    InternalOptions {}
 
 export type Cache = Map<string, CosmiconfigResult>;
 

--- a/test/caches.test.ts
+++ b/test/caches.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
-import { TempDir } from './util';
 import { cosmiconfig, cosmiconfigSync } from '../src';
+import { TempDir } from './util';
 
 const temp = new TempDir();
 
@@ -52,15 +52,17 @@ describe('cache is not used initially', () => {
   };
 
   test('async', async () => {
+    const explorer = cosmiconfig('foo');
     const readFileSpy = jest.spyOn(fs, 'readFile');
-    const cachedSearch = cosmiconfig('foo').search;
+    const cachedSearch = explorer.search;
     const result = await cachedSearch(searchPath);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
+    const explorer = cosmiconfigSync('foo');
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const cachedSearchSync = cosmiconfigSync('foo').search;
+    const cachedSearchSync = explorer.search;
     const result = cachedSearchSync(searchPath);
     checkResult(readFileSpy, result);
   });
@@ -260,24 +262,22 @@ describe('cache is not used in a new cosmiconfig instance', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
     // First pass, prime the cache ...
     await cosmiconfig('foo').search(searchPath);
-    // Reset readFile mocks and search again.
-    readFileSpy.mockClear();
-
-    const result = await cosmiconfig('foo').search(searchPath);
+    // Search again.
+    const explorer = cosmiconfig('foo');
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(searchPath);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
     // First pass, prime the cache ...
     cosmiconfigSync('foo').search(searchPath);
-    // Reset readFile mocks and search again.
-    readFileSpy.mockClear();
-
-    const result = cosmiconfigSync('foo').search(searchPath);
+    // Search again.
+    const explorer = cosmiconfigSync('foo');
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(searchPath);
     checkResult(readFileSpy, result);
   });
 });

--- a/test/failed-directories.test.ts
+++ b/test/failed-directories.test.ts
@@ -80,18 +80,22 @@ describe('gives up if it cannot find the file', () => {
   };
 
   test('async', async () => {
+    const explorer = cosmiconfig('foo', explorerOptions);
+
     const readFileSpy = jest.spyOn(fs, 'readFile');
     const statSpy = jest.spyOn(fs, 'stat');
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const result = await explorer.search(startDir);
     checkResult(statSpy, readFileSpy, result);
   });
 
   test('sync', () => {
+    const explorer = cosmiconfigSync('foo', explorerOptions);
+
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
     const statSpy = jest.spyOn(fs, 'statSync');
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const result = explorer.search(startDir);
     checkResult(statSpy, readFileSpy, result);
   });
 });
@@ -139,16 +143,18 @@ describe('stops at stopDir and gives up', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -74,11 +74,13 @@ describe('cosmiconfig', () => {
   });
 
   describe('creates explorer with default options if not specified', () => {
-    const checkResult = (mock: jest.SpyInstance) => {
-      expect(mock.mock.calls.length).toEqual(1);
-      expect(mock.mock.calls[0].length).toEqual(1);
+    const checkResult = (mock: jest.SpyInstance, instanceNum: number) => {
+      const instanceIndex = instanceNum - 1;
+      expect(mock.mock.calls.length).toEqual(instanceNum);
+      expect(mock.mock.calls[instanceIndex].length).toEqual(1);
 
-      const { transform, loaders, ...explorerOptions } = mock.mock.calls[0][0];
+      const { transform, loaders, ...explorerOptions } =
+        mock.mock.calls[instanceIndex][0];
       expect(transform.name).toBe('identity');
       const loaderFunctionsByName = getLoaderFunctionsByName(loaders);
       expect(loaderFunctionsByName).toEqual({
@@ -117,12 +119,12 @@ describe('cosmiconfig', () => {
 
     test('async', () => {
       cosmiconfig(moduleName);
-      checkResult(createExplorerMock);
+      checkResult(createExplorerMock, 1);
     });
 
     test('sync', () => {
       cosmiconfigSync(moduleName);
-      checkResult(createExplorerSyncMock);
+      checkResult(createExplorerSyncMock, 2);
     });
   });
 
@@ -171,10 +173,12 @@ describe('cosmiconfig', () => {
       },
     };
 
-    const checkResult = (mock: jest.SpyInstance) => {
-      expect(mock.mock.calls.length).toEqual(1);
-      expect(mock.mock.calls[0].length).toEqual(1);
-      const { transform, loaders, ...explorerOptions } = mock.mock.calls[0][0];
+    const checkResult = (mock: jest.SpyInstance, instanceNum: number) => {
+      const instanceIndex = instanceNum - 1;
+      expect(mock.mock.calls.length).toEqual(instanceNum);
+      expect(mock.mock.calls[instanceIndex].length).toEqual(1);
+      const { transform, loaders, metaConfig, ...explorerOptions } =
+        mock.mock.calls[instanceIndex][0];
 
       expect(transform.name).toBe('identity');
       const loaderFunctionsByName = getLoaderFunctionsByName(loaders);
@@ -198,12 +202,12 @@ describe('cosmiconfig', () => {
 
     test('async', () => {
       cosmiconfig(moduleName, options);
-      checkResult(createExplorerMock);
+      checkResult(createExplorerMock, 1);
     });
 
     test('sync', () => {
       cosmiconfigSync(moduleName, options);
-      checkResult(createExplorerSyncMock);
+      checkResult(createExplorerSyncMock, 2);
     });
   });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,7 +12,12 @@ import { TempDir } from './util';
 const temp = new TempDir();
 
 function getLoaderFunctionsByName(loaders: Loaders) {
-  return Object.fromEntries(Object.entries(loaders).map(([extension, loader]) => [extension, loader.name]));
+  return Object.fromEntries(
+    Object.entries(loaders).map(([extension, loader]) => [
+      extension,
+      loader.name,
+    ]),
+  );
 }
 
 let cosmiconfig: typeof cosmiconfigModule;
@@ -105,7 +110,6 @@ describe('cosmiconfig', () => {
         stopDir: os.homedir(),
         cache: true,
         metaConfigFilePath: null,
-        searchInThisFile: false,
       });
     };
 
@@ -189,7 +193,6 @@ describe('cosmiconfig', () => {
         ignoreEmptySearchPlaces: false,
         stopDir: __dirname,
         cache: false,
-        searchInThisFile: false,
         metaConfigFilePath: null,
       });
     };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,12 +12,7 @@ import { TempDir } from './util';
 const temp = new TempDir();
 
 function getLoaderFunctionsByName(loaders: Loaders) {
-  return Object.entries(loaders).reduce((acc, [extension, loader]) => {
-    return {
-      ...acc,
-      [extension]: loader.name,
-    };
-  }, {});
+  return Object.fromEntries(Object.entries(loaders).map(([extension, loader]) => [extension, loader.name]));
 }
 
 let cosmiconfig: typeof cosmiconfigModule;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-extraneous-class,@typescript-eslint/explicit-member-accessibility,@typescript-eslint/no-empty-function */
 import os from 'os';
-import { TempDir } from './util';
 import {
   cosmiconfig as cosmiconfigModule,
   cosmiconfigSync as cosmiconfigSyncModule,
@@ -8,21 +7,17 @@ import {
   LoaderSync,
 } from '../src';
 import { Loaders } from '../src/types';
+import { TempDir } from './util';
 
 const temp = new TempDir();
 
 function getLoaderFunctionsByName(loaders: Loaders) {
-  const loaderFunctionsByName = Object.entries(loaders).reduce(
-    (acc, [extension, loader]) => {
-      return {
-        ...acc,
-        [extension]: loader.name,
-      };
-    },
-    {},
-  );
-
-  return loaderFunctionsByName;
+  return Object.entries(loaders).reduce((acc, [extension, loader]) => {
+    return {
+      ...acc,
+      [extension]: loader.name,
+    };
+  }, {});
 }
 
 let cosmiconfig: typeof cosmiconfigModule;
@@ -114,6 +109,8 @@ describe('cosmiconfig', () => {
         ignoreEmptySearchPlaces: true,
         stopDir: os.homedir(),
         cache: true,
+        metaConfigFilePath: null,
+        searchInThisFile: false,
       });
     };
 
@@ -177,7 +174,7 @@ describe('cosmiconfig', () => {
       const instanceIndex = instanceNum - 1;
       expect(mock.mock.calls.length).toEqual(instanceNum);
       expect(mock.mock.calls[instanceIndex].length).toEqual(1);
-      const { transform, loaders, metaConfig, ...explorerOptions } =
+      const { transform, loaders, ...explorerOptions } =
         mock.mock.calls[instanceIndex][0];
 
       expect(transform.name).toBe('identity');
@@ -197,6 +194,8 @@ describe('cosmiconfig', () => {
         ignoreEmptySearchPlaces: false,
         stopDir: __dirname,
         cache: false,
+        searchInThisFile: false,
+        metaConfigFilePath: null,
       });
     };
 

--- a/test/meta-config.test.ts
+++ b/test/meta-config.test.ts
@@ -1,0 +1,244 @@
+import fs from 'fs';
+import { cosmiconfig, cosmiconfigSync } from '../src';
+import { TempDir } from './util';
+import SpyInstance = jest.SpyInstance;
+
+describe('cosmiconfig meta config', () => {
+  const temp = new TempDir();
+  beforeEach(() => {
+    temp.clean();
+  });
+
+  afterAll(() => {
+    // Remove temp.dir created for tests
+    temp.deleteTempDir();
+  });
+
+  describe('uses user-configured searchPlaces without placeholders', () => {
+    const currentDir = process.cwd();
+
+    beforeEach(() => {
+      temp.createDir('sub');
+      temp.createFile('.foorc', 'a: b');
+      temp.createFile('.foo-config', 'a: c');
+
+      process.chdir(temp.dir);
+    });
+
+    afterEach(() => {
+      process.chdir(currentDir);
+    });
+
+    async function runTest() {
+      const file = temp.absolutePath('.foo-config');
+      const startDir = temp.absolutePath('sub');
+      const explorerOptions = { stopDir: temp.absolutePath('.') };
+
+      const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+      const explorer = cosmiconfig('foo', explorerOptions);
+      expect(
+        temp
+          .getSpyPathCalls(readFileSyncSpy)
+          .filter((path) => !path.includes('/node_modules/')),
+      ).toEqual([
+        'package.json',
+        '.config.json',
+        '.config.yaml',
+        '.config.yml',
+      ]);
+      readFileSyncSpy.mockClear();
+
+      const readFileSpy = jest.spyOn(fs, 'readFile');
+      const result = await explorer.search(startDir);
+      expect(temp.getSpyPathCalls(readFileSpy)).toEqual([
+        'sub/.foo-config',
+        'sub/.foo.config.yml',
+        '.foo-config',
+      ]);
+
+      expect(result).toEqual({
+        config: { a: 'c' },
+        filepath: file,
+      });
+    }
+
+    test('without placeholder', async () => {
+      temp.createFile(
+        '.config.yml',
+        'cosmiconfig:\n  searchPlaces: [".foo-config", ".foo.config.yml"]',
+      );
+      await runTest();
+    });
+
+    test('with placeholder', async () => {
+      temp.createFile(
+        '.config.yml',
+        'cosmiconfig:\n  searchPlaces: [".{name}-config", ".{name}.config.yml"]',
+      );
+      await runTest();
+    });
+  });
+
+  test('ignores meta file without cosmiconfig key', async () => {
+    temp.createFile('.config.yml', 'foo:\n  a: c');
+
+    temp.createDir('sub');
+    temp.createFile('.foorc', 'a: b');
+
+    const currentDir = process.cwd();
+    process.chdir(temp.dir);
+
+    const startDir = temp.absolutePath('sub');
+    const explorerOptions = { stopDir: temp.absolutePath('.') };
+
+    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfig('foo', explorerOptions);
+
+    expect(
+      temp
+        .getSpyPathCalls(readFileSyncSpy)
+        .filter((path) => !path.includes('/node_modules/')),
+    ).toEqual([
+      'package.json',
+      '.config.json',
+      '.config.yaml',
+      '.config.yml',
+      '.config.js',
+      '.config.cjs',
+    ]);
+
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
+    expect(temp.getSpyPathCalls(readFileSpy)).toEqual([
+      'sub/package.json',
+      'sub/.foorc',
+      'sub/.foorc.json',
+      'sub/.foorc.yaml',
+      'sub/.foorc.yml',
+      'sub/.foorc.js',
+      'sub/.foorc.cjs',
+      'sub/.config/foorc',
+      'sub/.config/foorc.json',
+      'sub/.config/foorc.yaml',
+      'sub/.config/foorc.yml',
+      'sub/.config/foorc.js',
+      'sub/.config/foorc.cjs',
+      'sub/foo.config.js',
+      'sub/foo.config.cjs',
+      'package.json',
+      '.foorc',
+    ]);
+
+    expect(result).toEqual({
+      config: { a: 'b' },
+      filepath: temp.absolutePath('.foorc'),
+    });
+
+    process.chdir(currentDir);
+  });
+
+  describe('checks config in meta file', () => {
+    const currentDir = process.cwd();
+
+    beforeEach(() => {
+      temp.createDir('sub');
+      temp.createFile('.foo-config', 'a: c');
+      process.chdir(temp.dir);
+    });
+
+    afterEach(() => {
+      process.chdir(currentDir);
+    });
+
+    describe('not existing', () => {
+      beforeEach(() => {
+        temp.createFile(
+          '.config.yml',
+          'cosmiconfig:\n  searchPlaces: [".foo-config"]\n  searchInThisFile: true',
+        );
+      });
+
+      const file = temp.absolutePath('.foo-config');
+      const explorerOptions = { stopDir: temp.absolutePath('.') };
+
+      function checkResult(
+        constructFiles: Array<string>,
+        readFileSpy: SpyInstance,
+        result: any,
+      ) {
+        expect(
+          constructFiles.filter((path) => !path.includes('/node_modules/')),
+        ).toEqual([
+          'package.json',
+          '.config.json',
+          '.config.yaml',
+          '.config.yml',
+        ]);
+
+        expect(
+          temp
+            .getSpyPathCalls(readFileSpy)
+            .filter((path) => !path.includes('/node_modules/')),
+        ).toEqual(['.config.yml', '.foo-config']);
+        expect(result).toEqual({
+          config: { a: 'c' },
+          filepath: file,
+        });
+      }
+
+      test('async', async () => {
+        const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+        const explorer = cosmiconfig('foo', explorerOptions);
+        const constructFiles = temp.getSpyPathCalls(readFileSyncSpy);
+        readFileSyncSpy.mockClear();
+
+        const readFileSpy = jest.spyOn(fs, 'readFile');
+        const result = await explorer.search(temp.dir);
+        checkResult(constructFiles, readFileSpy, result);
+      });
+
+      test('sync', () => {
+        const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+        const explorer = cosmiconfigSync('foo', explorerOptions);
+        const constructFiles = temp.getSpyPathCalls(readFileSyncSpy);
+
+        readFileSyncSpy.mockClear();
+        const result = explorer.search(temp.dir);
+        checkResult(constructFiles, readFileSyncSpy, result);
+      });
+    });
+
+    describe('existing', () => {
+      beforeEach(() => {
+        temp.createFile(
+          '.config.yml',
+          'cosmiconfig:\n  searchInThisFile: true\nfoo:\n  a: d',
+        );
+      });
+
+      function checkResult(readFileSpy: SpyInstance, result: any) {
+        expect(temp.getSpyPathCalls(readFileSpy)).toEqual(['.config.yml']);
+        expect(result).toEqual({
+          config: { a: 'd' },
+          filepath: temp.absolutePath('.config.yml'),
+        });
+      }
+
+      const explorerOptions = { stopDir: temp.absolutePath('.') };
+
+      test('async', async () => {
+        const explorer = cosmiconfig('foo', explorerOptions);
+        const readFileSpy = jest.spyOn(fs, 'readFile');
+        const result = await explorer.search(temp.dir);
+        checkResult(readFileSpy, result);
+      });
+
+      test('sync', () => {
+        const explorer = cosmiconfigSync('foo', explorerOptions);
+        const readFileSpy = jest.spyOn(fs, 'readFileSync');
+        const result = explorer.search(temp.dir);
+        checkResult(readFileSpy, result);
+      });
+    });
+  });
+});

--- a/test/meta-config.test.ts
+++ b/test/meta-config.test.ts
@@ -14,6 +14,17 @@ describe('cosmiconfig meta config', () => {
     temp.deleteTempDir();
   });
 
+  test('throws when trying to supply loaders', () => {
+    temp.createFile('.config.yml', 'cosmiconfig:\n  loaders: []');
+
+    const currentDir = process.cwd();
+    process.chdir(temp.dir);
+
+    expect(() => cosmiconfigSync('foo')).toThrow();
+
+    process.chdir(currentDir);
+  });
+
   describe('uses user-configured searchPlaces without placeholders', () => {
     const currentDir = process.cwd();
 

--- a/test/successful-directories.test.ts
+++ b/test/successful-directories.test.ts
@@ -67,16 +67,18 @@ describe('finds rc file in third searched dir, with a package.json lacking prop'
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -120,16 +122,18 @@ describe('finds package.json prop in second searched dir', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -181,14 +185,16 @@ describe('finds package.json with nested packageProp in second searched dir', ()
   };
 
   test('async', async () => {
+    const explorer = cosmiconfig('foo', explorerOptions);
     const readFileSpy = jest.spyOn(fs, 'readFile');
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
+    const explorer = cosmiconfigSync('foo', explorerOptions);
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -231,16 +237,18 @@ describe('finds JS file in first searched dir', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -284,16 +292,18 @@ describe('finds CJS file in first searched dir', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -328,16 +338,18 @@ describe('finds .foorc.js file in first searched dir', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -373,16 +385,18 @@ describe('finds .foorc.cjs file in first searched dir', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -416,16 +430,18 @@ describe("finds foorc file in first searched dir's .config subdir", () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -460,16 +476,18 @@ describe("finds foorc.json file in first searched dir's .config subdir", () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -505,16 +523,18 @@ describe("finds foorc.yaml file in first searched dir's .config subdir", () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -551,16 +571,18 @@ describe("finds foorc.yml file in first searched dir's .config subdir", () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -601,16 +623,18 @@ describe("finds foorc.js file in first searched dir's .config subdir", () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -652,16 +676,18 @@ describe("finds foorc.cjs file in first searched dir's .config subdir", () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -705,16 +731,18 @@ describe('skips over empty file to find JS file in first searched dir', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -747,16 +775,18 @@ describe('finds package.json in second dir searched, with alternate names', () =
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -792,15 +822,16 @@ describe('finds rc file in third searched dir, skipping packageProp, parsing ext
   };
 
   test('async', async () => {
+    const explorer = cosmiconfig('foo', explorerOptions);
     const readFileSpy = jest.spyOn(fs, 'readFile');
-
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
+    const explorer = cosmiconfigSync('foo', explorerOptions);
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -832,16 +863,18 @@ describe('finds package.json file in second searched dir, skipping JS and RC fil
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -886,16 +919,18 @@ describe('finds .foorc.json in second searched dir', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -926,16 +961,18 @@ describe('finds .foorc.yaml in first searched dir', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -967,16 +1004,18 @@ describe('finds .foorc.yml in first searched dir', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -1028,15 +1067,16 @@ describe('adding myfooconfig.js to searchPlaces, finds it in first searched dir'
   };
 
   test('async', async () => {
+    const explorer = cosmiconfig('foo', explorerOptions);
     const readFileSpy = jest.spyOn(fs, 'readFile');
-
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
+    const explorer = cosmiconfigSync('foo', explorerOptions);
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -1101,16 +1141,18 @@ describe('finds JS file traversing from cwd', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search();
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search();
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search();
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search();
     checkResult(readFileSpy, result);
   });
 });
@@ -1150,16 +1192,18 @@ describe('searchPlaces can include subdirectories', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -1196,16 +1240,18 @@ describe('directories with the same name as a search place are not treated as fi
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -1263,16 +1309,18 @@ describe('custom loaders allow non-default file types', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -1330,16 +1378,18 @@ describe('adding custom loaders allows for default and non-default file types', 
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -1387,16 +1437,18 @@ describe('defaults loaders can be overridden', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -1432,31 +1484,32 @@ describe('custom loaders can be async', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
     const explorerOptions = {
       ...baseOptions,
       loaders: {
         '.things': loadThingsAsync,
       },
     };
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     expect(loadThingsSync).not.toHaveBeenCalled();
     expect(loadThingsAsync).toHaveBeenCalled();
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
-
     const explorerOptions = {
       ...baseOptions,
       loaders: {
         '.things': loadThingsSync,
       },
     };
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     expect(loadThingsSync).toHaveBeenCalled();
     expect(loadThingsAsync).not.toHaveBeenCalled();
     checkResult(readFileSpy, result);
@@ -1494,9 +1547,10 @@ describe('a custom loader entry can include just an async loader', () => {
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -1534,16 +1588,18 @@ describe('a custom loader entry can include only a sync loader and work for both
   };
 
   test('async', async () => {
-    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorer = cosmiconfig('foo', explorerOptions);
 
-    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const result = await explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 
   test('sync', () => {
-    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const explorer = cosmiconfigSync('foo', explorerOptions);
 
-    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+    const result = explorer.search(startDir);
     checkResult(readFileSpy, result);
   });
 });


### PR DESCRIPTION
This change intends to make configuration more configurable for the end users, to suit the end user's project structure rather than the structures that (possibly multiple different) tooling maintainers imagined.

## Examples

With a file named `.config.yml` in your project root with the following contents:

```yml
cosmiconfig:
  searchPlaces:
    - .config/{name}.yml
```

and given that you're using stylelint and prettier (with both using a version of cosmiconfig that supports this), cosmiconfig will *only* look at the file `.config/stylelint.yml` and `.config/prettier.yml`.

The same should work from a package.json "cosmiconfig" key.

An additional feature I plan to add here is to be able to put configuration for cosmiconfig consumers directly into this file, a little bit like it works now in package.json (#261):

```yml
cosmiconfig:
  searchPlaces:
    - .config/{name}.yml
  searchInThisFile: true # bikeshedding proposals encouraged

prettier:
  printWidth: 80
```

This was in a previous local version of mine, but I decided to remove it, because the general approach seemed too shaky to me, but I intend to try again.

## To do

- [x] Enable user to specify explorer options within `package.json` using a `cosmiconfig` key
- [x] Enable user to specify explorer options in a `.config.{yml,yaml,json,js,cjs}` file using a `cosmiconfig` key
- [x] Enable user to put *all* configuration in said file
- [ ] Optional: figure out a way to specify loaders from non-JS files (could also offload this to a new issue to implement later, but then we should probably throw for now when someone tries to specify the `loaders` key in a non-JS file)
  - #290 
- [x] Fix existing tests to not spy on reading this early stage
- [x] Create new tests (get coverage back to 100%)
- [x] Add documentation to README
- [x] Add short summary to CHANGELOG

Fixes #261 

This is intended to be in a *minor* update, so there should be no breaking changes.

Please add your thoughts to this, I appreciate any feedback 🙂 