### PR TITLE
fix: accept type parameter for `CosmiconfigResult`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,8 @@ export type Config = any;
 /**
  * @public
  */
-export type CosmiconfigResult = {
-  config: Config;
+export type CosmiconfigResult<T = Config> = {
+  config: T;
   filepath: string;
   isEmpty?: boolean;
 } | null;


### PR DESCRIPTION
The `Config` type is actually `any`, so the type-check may have no effect. This change realizes stricter type-check by accepting a type parameter for the `CosmiconfigResult` type.

The following example can find an incorrect property name, thanks to this change.

```ts
// src/types-test.ts
import { cosmiconfig, type CosmiconfigResult } from './index';

type FooConfig = { foo: string };

cosmiconfig('foo')
  .search()
  .then((result: CosmiconfigResult<FooConfig>) => {
    const foo: string = result?.config.bar; // `.bar` is incorrect
    console.log({ foo });
  })
  .catch((error) => console.error(error));
```

```
src/types-test.ts:8:40 - error TS2339: Property 'bar' does not exist on type 'FooConfig'.

8     const foo: string = result?.config.bar;
                                         ~~~
```

> [!NOTE]
> See also https://github.com/stylelint/stylelint/pull/7543