### PR TITLE
Make loading of TS config safer

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -5,6 +5,7 @@ import { rm, writeFile } from 'fs/promises';
 import path from 'path';
 import { pathToFileURL } from 'url';
 import { Loader, LoaderSync } from './types.js';
+import { threadId } from 'worker_threads';
 
 let importFresh: typeof import('import-fresh');
 export const loadJsSync: LoaderSync = function loadJsSync(filepath) {
@@ -99,7 +100,8 @@ export const loadTs: Loader = async function loadTs(filepath, content) {
   if (typescript === undefined) {
     typescript = (await import('typescript')).default;
   }
-  const compiledFilepath = `${filepath.slice(0, -2)}mjs`;
+  const parallelSafeStamp = `-pid:${process.pid}-thread:${threadId}`;
+  const compiledFilepath = `${filepath.slice(0, -2)}-${parallelSafeStamp}.mjs`;
   let transpiledContent;
   try {
     try {


### PR DESCRIPTION
This ensures multiple processes/threads can load the TS config files without race conditions.

# The problem in detail.

If you run multiple processes that load the same TS files, one process may delete the file right before the other process is able to read it.

This error is hard to reproduce as it requires running multiple processes and getting lucky.
It would have probably surfaced sooner if you used the `wx` flags (as `writeFile(path, content, { flag: 'wx' })` - which would throw an error if the file already exists.)

# Drawbacks of solution

If a developer uses the `__filename` special variable in the ts file and that is based to some code that requires the basename to match the config file, an error scenario may be produced.

# Alternatives
Consider requiring the code without writing to a file using something like the following:

```js
const commonjsRequireSource = (source: string, sourceFilename: string) => {
  const thisModule = new Module(sourceFilename, module);
  const thisRequire = createRequire(sourceFilename);
  vm.runInNewContext(source, {
    module: thisModule,
    exports: thisModule.exports as unknown,
    require: thisRequire,
    process,
  });

  return thisModule.exports as unknown;
};
```
