### PR TITLE
Removed Parse JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,13 +71,11 @@
   "dependencies": {
     "env-paths": "^2.2.1",
     "import-fresh": "^3.3.0",
-    "js-yaml": "^4.1.0",
-    "parse-json": "^5.2.0"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^14",
-    "@types/parse-json": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "@typescript-eslint/parser": "^6.5.0",
     "@vitest/coverage-istanbul": "^0.34.3",

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -38,14 +38,9 @@ export const loadJs: Loader = async function loadJs(filepath) {
   }
 };
 
-let parseJson: typeof import('parse-json');
 export const loadJson: LoaderSync = function loadJson(filepath, content) {
-  if (parseJson === undefined) {
-    parseJson = require('parse-json');
-  }
-
   try {
-    return parseJson(content);
+    return JSON.parse(content);
   } catch (error) {
     error.message = `JSON Error in ${filepath}:\n${error.message}`;
     throw error;


### PR DESCRIPTION
Removing `parseJSON`, which in turn removes 5 packages from the dependency tree: parse-json, @babel/code-frame, error-ex, json-parse-even-better-errors, and lines-and-columns.

1. parse-json internally calls JSON.parse as its primary path — it only adds enhanced error formatting (code frames via @babel/code-frame) when parsing fails.
2. Cosmiconfig called parseJson(content) with only one argument — it never used parse-json's reviver or filename parameters, and never referenced its JSONError type or
   codeFrame property.