### PR TITLE
Remove "import-fresh" as a dependency in favor of Node.js API

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   },
   "dependencies": {
     "env-paths": "^2.2.1",
-    "import-fresh": "^3.3.0",
     "js-yaml": "^4.1.0",
     "parse-json": "^5.2.0"
   },

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -7,13 +7,9 @@ import { pathToFileURL } from 'url';
 import { Loader, LoaderSync } from './types.js';
 import { randomUUID } from 'crypto';
 
-let importFresh: typeof import('import-fresh');
 export const loadJsSync: LoaderSync = function loadJsSync(filepath) {
-  if (importFresh === undefined) {
-    importFresh = require('import-fresh');
-  }
-
-  return importFresh(filepath);
+  delete require.cache[require.resolve(filepath)];
+  return require(filepath);
 };
 
 export const loadJs: Loader = async function loadJs(filepath) {


### PR DESCRIPTION
This change removes "import-fresh" as it is an unnecessary dependency. The same functionally and intent is achievable with the Node.js API. This helps reduce the size and scope of node_modules within projects that consume cosmiconfig either directly or as a transient dependency.