### PR TITLE
fix: avoid bundling typescript when the TS loader is unused

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -68,11 +68,19 @@ export const loadYaml: LoaderSync = function loadYaml(filepath, content) {
   }
 };
 
+/**
+ * The `typescript` package name is referenced through this variable rather than
+ * as a string literal so that bundlers (e.g. Vite/Rollup) cannot statically
+ * trace the `require`/`import` below. This keeps the ~5MB `typescript` package
+ * out of consumer bundles when the TypeScript loader is not used, while the
+ * module is still resolved lazily at runtime when the loader runs.
+ */
+const typescriptPackageName = 'typescript';
 let typescript: typeof import('typescript');
 export const loadTsSync: LoaderSync = function loadTsSync(filepath, content) {
   /* istanbul ignore next -- @preserve */
   if (typescript === undefined) {
-    typescript = require('typescript');
+    typescript = require(typescriptPackageName);
   }
   const compiledFilepath = `${filepath}.${randomUUID()}.cjs`;
   try {
@@ -99,7 +107,7 @@ export const loadTsSync: LoaderSync = function loadTsSync(filepath, content) {
 
 export const loadTs: Loader = async function loadTs(filepath, content) {
   if (typescript === undefined) {
-    typescript = (await import('typescript')).default;
+    typescript = (await import(typescriptPackageName)).default;
   }
   const compiledFilepath = `${filepath}.${randomUUID()}.mjs`;
   let transpiledContent;

--- a/test/loaders.test.ts
+++ b/test/loaders.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeEach, describe, expect, test } from 'vitest';
+import { cosmiconfig, cosmiconfigSync } from '../src';
+import { TempDir } from './util';
+
+const temp = new TempDir();
+
+beforeEach(() => {
+  temp.clean();
+});
+
+afterAll(() => {
+  temp.deleteTempDir();
+});
+
+describe('TypeScript loader bundler safety', () => {
+  // The `typescript` package is an optional peer dependency (~5MB). It must not
+  // be referenced as a static `require('typescript')` / `import('typescript')`
+  // string literal, otherwise bundlers such as Vite/Rollup statically trace it
+  // and pull it into consumer bundles even when the `.ts` loader is unused.
+  // See https://github.com/cosmiconfig/cosmiconfig/issues/358.
+  test('does not reference `typescript` with a static literal specifier', () => {
+    const loadersSource = readFileSync(
+      path.resolve(fileURLToPath(import.meta.url), '../../src/loaders.ts'),
+      'utf8',
+    );
+
+    // `require('typescript')` and a runtime `import('typescript')` are statically
+    // analyzable by bundlers. A `typeof import('typescript')` type annotation is
+    // erased at compile time, so it is excluded here via the negative lookbehind.
+    expect(loadersSource).not.toMatch(/require\(\s*['"]typescript['"]\s*\)/);
+    expect(loadersSource).not.toMatch(
+      /(?<!typeof\s)import\(\s*['"]typescript['"]\s*\)/,
+    );
+  });
+});
+
+describe('TypeScript loader still works when used explicitly', () => {
+  beforeEach(() => {
+    temp.createFile('foo.ts', 'export default { foo: true } as any;');
+  });
+
+  const file = temp.absolutePath('foo.ts');
+  const checkResult = (result: any) => {
+    expect(result.config).toEqual({ foo: true });
+    expect(result.filepath).toBe(file);
+  };
+
+  test('async', async () => {
+    const result = await cosmiconfig('loaders-tests').load(file);
+    checkResult(result);
+  }, 20000);
+
+  test('sync', () => {
+    const result = cosmiconfigSync('loaders-tests').load(file);
+    checkResult(result);
+  });
+});


### PR DESCRIPTION
## Problem
`src/loaders.ts` referenced the `typescript` package via a string literal (`require('typescript')` / `import('typescript')`) inside the TS loaders. Bundlers such as Vite/Rollup statically trace those specifiers and include the ~5MB `typescript` package in consumer bundles even when the `.ts` loader is never used.

## Fix
Reference the package name through a variable (`const typescriptPackageName = 'typescript'`) so the `require`/`import` specifier is not a static string. `typescript` is still resolved lazily at runtime when the loader actually runs, but bundlers can no longer statically trace it, keeping it out of bundles that don't use the TS loader.

## Test
Added `test/loaders.test.ts` verifying the TS loaders still load and transpile correctly.

Closes #358