### PR TITLE
fix: stop project search at package boundary

### DIFF
--- a/src/Explorer.ts
+++ b/src/Explorer.ts
@@ -210,11 +210,10 @@ export class Explorer extends ExplorerBase<InternalOptions> {
           /* istanbul ignore if -- @preserve */
           if (parentDir === currentDir) {
             // we're probably at the root of the directory structure
-            break;
+            return;
           }
           currentDir = parentDir;
         }
-        return;
       }
       case 'global': {
         yield* this.getGlobalDirs(startDir);

--- a/src/Explorer.ts
+++ b/src/Explorer.ts
@@ -195,11 +195,16 @@ export class Explorer extends ExplorerBase<InternalOptions> {
         let currentDir = startDir;
         while (true) {
           yield { path: currentDir, isGlobalConfig: false };
+          let foundPackageFile = false;
           for (const ext of ['json', 'yaml']) {
             const packageFile = path.join(currentDir, `package.${ext}`);
             if (await this.#fileExists(packageFile)) {
+              foundPackageFile = true;
               break;
             }
+          }
+          if (foundPackageFile) {
+            return;
           }
           const parentDir = path.dirname(currentDir);
           /* istanbul ignore if -- @preserve */

--- a/src/ExplorerSync.ts
+++ b/src/ExplorerSync.ts
@@ -187,11 +187,16 @@ export class ExplorerSync extends ExplorerBase<InternalOptionsSync> {
         let currentDir = startDir;
         while (true) {
           yield { path: currentDir, isGlobalConfig: false };
+          let foundPackageFile = false;
           for (const ext of ['json', 'yaml']) {
             const packageFile = path.join(currentDir, `package.${ext}`);
             if (this.#fileExists(packageFile)) {
+              foundPackageFile = true;
               break;
             }
+          }
+          if (foundPackageFile) {
+            return;
           }
           const parentDir = path.dirname(currentDir);
           /* istanbul ignore if -- @preserve */

--- a/src/ExplorerSync.ts
+++ b/src/ExplorerSync.ts
@@ -202,11 +202,10 @@ export class ExplorerSync extends ExplorerBase<InternalOptionsSync> {
           /* istanbul ignore if -- @preserve */
           if (parentDir === currentDir) {
             // we're probably at the root of the directory structure
-            break;
+            return;
           }
           currentDir = parentDir;
         }
-        return;
       }
       case 'global': {
         yield* this.getGlobalDirs(startDir);

--- a/test/search-strategies.test.ts
+++ b/test/search-strategies.test.ts
@@ -120,6 +120,7 @@ describe('search strategies', () => {
       temp.createDir('a/b');
       temp.createFile('a/package.json', '');
       temp.createFile('.bazrc.yml', 'result: 6');
+      temp.createFile('.foorc.yml', 'result: 7');
     });
 
     const startDir = temp.absolutePath('a/b');
@@ -135,6 +136,18 @@ describe('search strategies', () => {
 
     test('sync', () => {
       const explorer = cosmiconfigSync('bar', explorerOptions);
+      const result = explorer.search(startDir);
+      expect(result).toBeNull();
+    });
+
+    test('async stops at the first package file', async () => {
+      const explorer = cosmiconfig('foo', explorerOptions);
+      const result = await explorer.search(startDir);
+      expect(result).toBeNull();
+    });
+
+    test('sync stops at the first package file', () => {
+      const explorer = cosmiconfigSync('foo', explorerOptions);
       const result = explorer.search(startDir);
       expect(result).toBeNull();
     });


### PR DESCRIPTION
## Summary

This updates `searchStrategy: "project"` so it stops traversing parent directories after reaching the first directory with `package.json` or `package.yaml`.

## What changed

- Stop async project search after the package-boundary directory has been searched.
- Apply the same behavior to the sync search path.
- Add async and sync tests covering a same-module config above the package boundary.

## Why

The README and changelog describe `project` search as traversing upward until a package file is found. Previously, traversal could continue above that package boundary and load a matching config from a parent directory.

## Tests

- `test/search-strategies.test.ts`: 10 passed

I also ran a broader search-related subset. It showed one pre-existing baseline failure in `test/successful-directories.test.ts` related to `fs.readFileSync` spy calls from `import-fresh` dependencies under this container install layout; the same failure occurs on the unmodified checkout, so it is unrelated to this patch.

## Compatibility notes

This may change behavior for users who were relying on `searchStrategy: "project"` finding configs above the nearest package file, but it matches the documented package-boundary behavior.