### PR TITLE
fix: correctly decode UTF-16 (BOM-prefixed) config files

### DIFF
--- a/src/Explorer.ts
+++ b/src/Explorer.ts
@@ -9,7 +9,12 @@ import {
   InternalOptions,
   DirToSearch,
 } from './types.js';
-import { emplace, getPropertyByPath, isDirectory } from './util.js';
+import {
+  decodeFileContent,
+  emplace,
+  getPropertyByPath,
+  isDirectory,
+} from './util.js';
 
 /**
  * @internal
@@ -99,7 +104,7 @@ export class Explorer extends ExplorerBase<InternalOptions> {
     filepath: string,
     importStack: Array<string> = [],
   ): Promise<CosmiconfigResult> {
-    const contents = await fs.readFile(filepath, { encoding: 'utf-8' });
+    const contents = decodeFileContent(await fs.readFile(filepath));
     return this.toCosmiconfigResult(
       filepath,
       await this.#loadConfigFileWithImports(filepath, contents, importStack),

--- a/src/ExplorerSync.ts
+++ b/src/ExplorerSync.ts
@@ -9,7 +9,12 @@ import {
   InternalOptionsSync,
   DirToSearch,
 } from './types.js';
-import { emplace, getPropertyByPath, isDirectorySync } from './util.js';
+import {
+  decodeFileContent,
+  emplace,
+  getPropertyByPath,
+  isDirectorySync,
+} from './util.js';
 
 /**
  * @internal
@@ -97,7 +102,7 @@ export class ExplorerSync extends ExplorerBase<InternalOptionsSync> {
     filepath: string,
     importStack: Array<string> = [],
   ): CosmiconfigResult {
-    const contents = fs.readFileSync(filepath, 'utf8');
+    const contents = decodeFileContent(fs.readFileSync(filepath));
     return this.toCosmiconfigResult(
       filepath,
       this.#loadConfigFileWithImports(filepath, contents, importStack),

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,6 +42,21 @@ export function getPropertyByPath(
   }, source);
 }
 
+// UTF-16LE and UTF-16BE byte-order marks. A config file saved with one of
+// these encodings (e.g. via PowerShell's default `Out-File` redirection on
+// Windows) is not valid UTF-8, so it must be decoded accordingly instead of
+// being passed through the UTF-8 path, which would otherwise produce garbage.
+/** @internal */
+export function decodeFileContent(buffer: Buffer): string {
+  if (buffer[0] === 0xff && buffer[1] === 0xfe) {
+    return new TextDecoder('utf-16le').decode(buffer);
+  }
+  if (buffer[0] === 0xfe && buffer[1] === 0xff) {
+    return new TextDecoder('utf-16be').decode(buffer);
+  }
+  return buffer.toString('utf-8');
+}
+
 /** @internal */
 export function removeUndefinedValuesFromObject(
   options: Record<string, unknown>,

--- a/test/decodeFileContent.test.ts
+++ b/test/decodeFileContent.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from 'vitest';
+import { decodeFileContent } from '../src/util';
+
+// UTF-16BE has no built-in Node Buffer encoding, so derive it by
+// byte-swapping the UTF-16LE encoding of the same string.
+function utf16beBuffer(contents: string): Buffer {
+  const le = Buffer.from(contents, 'utf16le');
+  const be = Buffer.alloc(le.length);
+  for (let i = 0; i < le.length; i += 2) {
+    be[i] = le[i + 1];
+    be[i + 1] = le[i];
+  }
+  return be;
+}
+
+describe('with a UTF-16LE byte-order mark', () => {
+  test('decodes as UTF-16LE and strips the BOM', () => {
+    const bom = Buffer.from([0xff, 0xfe]);
+    const content = Buffer.from('{ "foo": true }', 'utf16le');
+    expect(decodeFileContent(Buffer.concat([bom, content]))).toBe(
+      '{ "foo": true }',
+    );
+  });
+});
+
+describe('with a UTF-16BE byte-order mark', () => {
+  test('decodes as UTF-16BE and strips the BOM', () => {
+    const bom = Buffer.from([0xfe, 0xff]);
+    const content = utf16beBuffer('{ "foo": true }');
+    expect(decodeFileContent(Buffer.concat([bom, content]))).toBe(
+      '{ "foo": true }',
+    );
+  });
+});
+
+describe('with no UTF-16 byte-order mark', () => {
+  test('decodes as UTF-8, identically to Buffer#toString("utf-8")', () => {
+    const content = Buffer.from('{ "foo": true }', 'utf8');
+    expect(decodeFileContent(content)).toBe(content.toString('utf-8'));
+  });
+
+  test('leaves a UTF-8 byte-order mark untouched, matching prior behavior', () => {
+    const bom = Buffer.from([0xef, 0xbb, 0xbf]);
+    const content = Buffer.concat([
+      bom,
+      Buffer.from('{ "foo": true }', 'utf8'),
+    ]);
+    expect(decodeFileContent(content)).toBe(content.toString('utf-8'));
+    expect(decodeFileContent(content).charCodeAt(0)).toBe(0xfeff);
+  });
+});

--- a/test/decodeFileContent.test.ts
+++ b/test/decodeFileContent.test.ts
@@ -1,17 +1,6 @@
 import { describe, test, expect } from 'vitest';
 import { decodeFileContent } from '../src/util';
-
-// UTF-16BE has no built-in Node Buffer encoding, so derive it by
-// byte-swapping the UTF-16LE encoding of the same string.
-function utf16beBuffer(contents: string): Buffer {
-  const le = Buffer.from(contents, 'utf16le');
-  const be = Buffer.alloc(le.length);
-  for (let i = 0; i < le.length; i += 2) {
-    be[i] = le[i + 1];
-    be[i + 1] = le[i];
-  }
-  return be;
-}
+import { utf16beBuffer } from './util';
 
 describe('with a UTF-16LE byte-order mark', () => {
   test('decodes as UTF-16LE and strips the BOM', () => {

--- a/test/successful-files.test.ts
+++ b/test/successful-files.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import {
   afterAll,
   afterEach,
@@ -16,6 +17,18 @@ function randomString(): string {
   return Math.random().toString(36).substring(7);
 }
 
+// UTF-16BE has no built-in Node Buffer encoding, so derive it by
+// byte-swapping the UTF-16LE encoding of the same string.
+function utf16beBuffer(contents: string): Buffer {
+  const le = Buffer.from(contents, 'utf16le');
+  const be = Buffer.alloc(le.length);
+  for (let i = 0; i < le.length; i += 2) {
+    be[i] = le[i + 1];
+    be[i + 1] = le[i];
+  }
+  return be;
+}
+
 beforeEach(() => {
   temp.clean();
 });
@@ -31,6 +44,54 @@ describe('loads defined JSON config path', () => {
   });
 
   const file = temp.absolutePath('foo.json');
+  const checkResult = (result: any) => {
+    expect(result.config).toEqual({ foo: true });
+    expect(result.filepath).toBe(file);
+  };
+
+  test('async', async () => {
+    const result = await cosmiconfig('successful-files-tests').load(file);
+    checkResult(result);
+  });
+
+  test('sync', () => {
+    const result = cosmiconfigSync('successful-files-tests').load(file);
+    checkResult(result);
+  });
+});
+
+describe('loads UTF-16LE encoded JSON config path (with BOM)', () => {
+  const file = temp.absolutePath('foo-utf16le.json');
+  beforeEach(() => {
+    const bom = Buffer.from([0xff, 0xfe]);
+    const content = Buffer.from('{ "foo": true }\n', 'utf16le');
+    fs.writeFileSync(file, Buffer.concat([bom, content]));
+  });
+
+  const checkResult = (result: any) => {
+    expect(result.config).toEqual({ foo: true });
+    expect(result.filepath).toBe(file);
+  };
+
+  test('async', async () => {
+    const result = await cosmiconfig('successful-files-tests').load(file);
+    checkResult(result);
+  });
+
+  test('sync', () => {
+    const result = cosmiconfigSync('successful-files-tests').load(file);
+    checkResult(result);
+  });
+});
+
+describe('loads UTF-16BE encoded JSON config path (with BOM)', () => {
+  const file = temp.absolutePath('foo-utf16be.json');
+  beforeEach(() => {
+    const bom = Buffer.from([0xfe, 0xff]);
+    const content = utf16beBuffer('{ "foo": true }\n');
+    fs.writeFileSync(file, Buffer.concat([bom, content]));
+  });
+
   const checkResult = (result: any) => {
     expect(result.config).toEqual({ foo: true });
     expect(result.filepath).toBe(file);

--- a/test/successful-files.test.ts
+++ b/test/successful-files.test.ts
@@ -9,24 +9,12 @@ import {
   vi,
 } from 'vitest';
 import { cosmiconfig, cosmiconfigSync } from '../src';
-import { TempDir } from './util';
+import { TempDir, utf16beBuffer } from './util';
 
 const temp = new TempDir();
 
 function randomString(): string {
   return Math.random().toString(36).substring(7);
-}
-
-// UTF-16BE has no built-in Node Buffer encoding, so derive it by
-// byte-swapping the UTF-16LE encoding of the same string.
-function utf16beBuffer(contents: string): Buffer {
-  const le = Buffer.from(contents, 'utf16le');
-  const be = Buffer.alloc(le.length);
-  for (let i = 0; i < le.length; i += 2) {
-    be[i] = le[i + 1];
-    be[i + 1] = le[i];
-  }
-  return be;
 }
 
 beforeEach(() => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -110,3 +110,15 @@ export class TempDir {
 export function isNotMjs(filePath: string): boolean {
   return path.extname(filePath) !== '.mjs';
 }
+
+// UTF-16BE has no built-in Node Buffer encoding, so derive it by
+// byte-swapping the UTF-16LE encoding of the same string.
+export function utf16beBuffer(contents: string): Buffer {
+  const le = Buffer.from(contents, 'utf16le');
+  const be = Buffer.alloc(le.length);
+  for (let i = 0; i < le.length; i += 2) {
+    be[i] = le[i + 1];
+    be[i + 1] = le[i];
+  }
+  return be;
+}


### PR DESCRIPTION
## What changed

`Explorer.ts` and `ExplorerSync.ts` hardcoded UTF-8 when reading a config file (`fs.readFile(filepath, { encoding: 'utf-8' })` / `fs.readFileSync(filepath, 'utf8')`). A config file saved as UTF-16LE or UTF-16BE — for example via PowerShell's default `Out-File`/redirection encoding on Windows, a very common way Windows users create files like `.releaserc` — gets decoded as garbage instead of being parsed correctly.

This adds a `decodeFileContent` helper that sniffs the leading bytes for a UTF-16LE BOM (`0xFF 0xFE`) or UTF-16BE BOM (`0xFE 0xFF`) and decodes with the matching encoding via `TextDecoder`, before falling back to the existing UTF-8 path unchanged. Applied symmetrically to both the async and sync read paths.

## Why (originating report)

This was originally reported against semantic-release, which delegates all config loading to cosmiconfig: [semantic-release/semantic-release#1624](https://github.com/semantic-release/semantic-release/issues/1624) — ".releaserc is not correctly parsed when encoding of file is utf16le".

- @gr2m (semantic-release maintainer): *"We'd love a PR to make reading the config files work correctly in this case."*
- @travi (semantic-release maintainer), on revisiting in 2024: *"i imagine this is more related to cosmiconfig than directly about semantic-release. i would recommend starting there."*

semantic-release's `lib/get-config.js` delegates entirely to `cosmiconfig(CONFIG_NAME).search(cwd)`, so the actual bug lives here. There's no cosmiconfig issue yet for this — happy to open one if you'd prefer that first.

## Testing

- Added `test/decodeFileContent.test.ts`, unit-testing the new decode helper directly: UTF-16LE, UTF-16BE, plain UTF-8, and UTF-8-with-BOM (confirming the UTF-8 path — BOM or not — is byte-for-byte unchanged from before).
- Added UTF-16LE and UTF-16BE fixture-based end-to-end tests to `test/successful-files.test.ts` (async + sync), following the file's existing pattern.
- `npm test` passes: 267/267 tests, 100% coverage maintained.
- `npm run lint` clean.
